### PR TITLE
Add repo-local .otoxan operating pack

### DIFF
--- a/.otoxan/README.md
+++ b/.otoxan/README.md
@@ -1,0 +1,34 @@
+# bd-site .otoxan operating pack
+
+This directory is the repo-local operating pack for AI agents working on `berryhill/bd-site`, Matt Berryhill's personal brand website at `berryhill.dev`.
+
+Read order for any agent session:
+
+1. `.otoxan/README.md` — operating contract and read order.
+2. `.otoxan/context.md` — repository identity, stack, brand context, and source-of-truth notes.
+3. `.otoxan/rules/agent-onboarding.md` — minimum repo readback for future agents.
+4. `.otoxan/rules/github-issue-to-pr.md` — required change-control path.
+5. `.otoxan/rules/safe-agent-work.md` — staging, validation, secrets, and deployment safety.
+6. `.otoxan/rules/content-and-brand.md` — personal brand/content rules.
+7. `.otoxan/rules/docs-and-contributing.md` — docs/source truth handling.
+8. `.otoxan/rules/no-embedded-wiki.md` — current wiki-status boundary.
+9. `.otoxan/flows/github-issue-to-pr.md` — default repo mutation flow.
+10. `.otoxan/flows/code-change.md` — app/source change flow.
+11. `.otoxan/flows/content-change.md` — blog/content change flow.
+12. `.otoxan/flows/repo-knowledge-update.md` — docs and operating-pack update flow.
+
+Hard rule: every material repository change goes through issue -> branch -> scoped commit -> PR. Do not direct-commit to `main`.
+
+Canonical repo/base branch:
+
+- Repository: `berryhill/bd-site`
+- Website: `https://berryhill.dev/`
+- Base branch: `main`
+- Package manager: `pnpm`
+- Validation suite: `pnpm run lint`, `pnpm run format:check`, `pnpm run build`
+
+Boundary for this pack:
+
+- `.otoxan/` describes how agents should work in this repository.
+- It is not application runtime code.
+- It should travel with the repo so future agents do not depend only on external onboarding reports, vector indexes, or one agent's memory.

--- a/.otoxan/context.md
+++ b/.otoxan/context.md
@@ -1,0 +1,69 @@
+# bd-site context
+
+## Repository identity
+
+`berryhill/bd-site` is the Astro-based website for Matt Berryhill's personal brand at `berryhill.dev`.
+
+The site positions Matt around agentic-first development, AI/ML systems, blockchain, crypto markets, digital music, and intelligent automation. Treat this as a brand surface, not a generic blog theme.
+
+## Current stack
+
+Verified from repository files during onboarding:
+
+- Astro 5.x site with AstroPaper lineage.
+- TypeScript using Astro strict TypeScript config.
+- TailwindCSS 4.x via `@tailwindcss/vite` and `@tailwindcss/typography`.
+- SSR/server output via `@astrojs/node` in standalone mode.
+- Markdown content under `src/data/blog/`.
+- Live content collection setup through `src/live.config.ts` and a custom filesystem loader.
+- RSS, dynamic OG image generation, custom sitemap/robots routes, and Pagefind dependencies.
+- Docker image deployment through GHCR.
+- Kubernetes/Helm deployment for `berryhill.dev`.
+- Production secrets managed outside the repo; do not commit `.env`, Doppler tokens, or production values files.
+
+## Important paths
+
+- `src/config.ts` — site identity, brand description, feature toggles, pagination, timezone, edit link, Calendly link.
+- `src/content.config.ts` — exports `BLOG_PATH`; live collections are defined elsewhere.
+- `src/live.config.ts` — live blog collection wiring.
+- `src/loaders/filesystem.ts` — custom recursive Markdown loader.
+- `src/data/blog/` — Markdown blog posts.
+- `src/pages/api/posts.ts` — content API for post create/update/delete.
+- `src/pages/about.md` — about page content.
+- `.github/workflows/ci.yml` — CI validation.
+- `.github/workflows/deploy.yaml` — GHCR/Helm deployment.
+- `helm/` — Kubernetes deployment chart.
+- `CLAUDE.md` — existing AI coding guidance; useful but not always fully current.
+- `API.md` — content API docs; useful but contains known mismatches with implementation.
+
+## Source-of-truth order
+
+When docs disagree, prefer this order:
+
+1. Current source code and config files.
+2. `package.json` scripts and dependency versions.
+3. CI workflow definitions.
+4. Deployment files.
+5. Repo docs such as README, API.md, and CLAUDE.md.
+6. External reports, memories, or agent summaries.
+
+Known cautions:
+
+- `package.json` currently defines `build` as `astro build`; do not assume extra `astro check` or Pagefind copy steps unless the script is changed.
+- Some upstream AstroPaper docs/templates remain in `.github/` and may not be fully bd-site-specific.
+- `API.md` and `src/pages/api/posts.ts` should be compared before API changes; docs and implementation have had shape/base-URL mismatches.
+- `src/config.ts` edit URL currently references `berryhilldev/bd-site`; verify repo owner paths before changing public edit links.
+
+## Brand frame
+
+This website should make Matt look like a serious operator in the AI/agentic systems space, not a generic AI commentator.
+
+Content and site changes should support:
+
+- Agentic-first development as a practical operating model.
+- AI/ML systems and automation as built things, not hype cycles.
+- Blockchain/crypto markets with specificity and grounded analysis.
+- Digital music/creative systems where relevant to Matt's work.
+- Clear, human, opinionated writing with concrete examples.
+
+Avoid generic AI slop, abstract futurism, exaggerated certainty, and copy that could belong to any AI influencer.

--- a/.otoxan/flows/code-change.md
+++ b/.otoxan/flows/code-change.md
@@ -1,0 +1,35 @@
+# Flow: code change
+
+Use for application/source changes in `berryhill/bd-site`.
+
+1. Read context:
+   - `.otoxan/README.md`
+   - `.otoxan/context.md`
+   - `.otoxan/rules/github-issue-to-pr.md`
+   - `.otoxan/rules/safe-agent-work.md`
+2. Confirm the controlling issue and intended path boundary.
+3. Start from fresh `main`:
+   - `git status --short --branch`
+   - `git fetch origin --prune`
+   - `git checkout main`
+   - `git pull --ff-only origin main`
+4. Create an issue-numbered branch.
+5. Inspect relevant files before editing. Prefer source/config over stale docs when they conflict.
+6. Make the smallest coherent change that solves the issue.
+7. Stage specific files only.
+8. Run validation:
+   - `pnpm run lint`
+   - `pnpm run format:check`
+   - `pnpm run build`
+9. Inspect staged diff:
+   - `git diff --stat --cached HEAD`
+   - `git diff --name-status --cached HEAD`
+10. Commit, push, and open a PR with:
+   - issue link
+   - summary
+   - files changed
+   - validation evidence
+   - source-code boundary statement
+   - residual risks
+
+If validation fails, fix and rerun. Do not open a PR claiming success without reporting unresolved failures.

--- a/.otoxan/flows/content-change.md
+++ b/.otoxan/flows/content-change.md
@@ -1,0 +1,25 @@
+# Flow: content change
+
+Use for blog posts, about-page edits, content metadata, and brand copy changes.
+
+1. Read:
+   - `.otoxan/context.md`
+   - `.otoxan/rules/content-and-brand.md`
+   - relevant files under `src/data/blog/`, `src/pages/about.md`, or `src/config.ts`
+2. Identify the strategic job:
+   - audience
+   - desired perception shift
+   - arc/campaign if known
+   - publication risk
+3. Confirm the content path boundary. Most content work should be content-only.
+4. For blog posts, follow the frontmatter schema used in `src/data/blog/`.
+5. Preserve Matt's positioning: agentic-first builder/operator, not generic AI pundit.
+6. For drafts, set `draft: true` unless the issue explicitly asks for publish-ready content.
+7. Do not invent facts, metrics, affiliations, client work, regulatory claims, or personal history.
+8. Run validation appropriate to the change:
+   - `pnpm run format:check`
+   - `pnpm run build`
+   - `pnpm run lint` when source/config is touched
+9. Open a PR with voice/brand rationale and validation evidence.
+
+If the content changes public claims about Matt, his work, compliance-sensitive topics, finance/crypto advice, or professional credentials, call out the review risk in the PR body.

--- a/.otoxan/flows/github-issue-to-pr.md
+++ b/.otoxan/flows/github-issue-to-pr.md
@@ -1,0 +1,29 @@
+# Flow: GitHub issue to PR
+
+Use this as the default repository mutation flow for `berryhill/bd-site`.
+
+1. Intake
+   - Read the issue, comments, labels, and acceptance criteria.
+   - Classify the path boundary: `.otoxan-only`, docs-only, content-only, app/source-code-touching, or deployment-touching.
+2. Prepare branch
+   - Verify clean worktree.
+   - Fetch/prune.
+   - Fast-forward `main` from `origin/main`.
+   - Create an issue-numbered branch.
+3. Execute scoped work
+   - Read relevant `.otoxan/` rules and repo files.
+   - Edit only files in scope.
+   - Stage specific files only.
+4. Validate
+   - `.otoxan-only`: inspect file list and Markdown readability.
+   - docs/content/source changes: run applicable `pnpm` validation.
+   - source/deployment changes: run full lint, format check, and build unless blocked.
+5. Pre-commit guard
+   - `git diff --stat --cached HEAD`
+   - `git diff --name-status --cached HEAD`
+   - Stop on unrelated files or unexpected deletions.
+6. Finalize
+   - Commit.
+   - Push.
+   - Open PR to `main`.
+   - Include issue link, summary, validation, changed files, path boundary, and residual risks.

--- a/.otoxan/flows/repo-knowledge-update.md
+++ b/.otoxan/flows/repo-knowledge-update.md
@@ -1,0 +1,20 @@
+# Flow: repo knowledge update
+
+Use when updating `.otoxan/`, repo docs, AI guidance, or operating context.
+
+1. Treat source code and config as primary evidence.
+2. Inspect current repo files before changing guidance.
+3. Capture durable rules, not temporary task status.
+4. If adding process guidance, prefer class-level rules and reusable flows over one-off notes.
+5. Keep `.otoxan/` concise enough to be read at the start of a future task.
+6. Route changes through issue -> branch -> PR.
+7. For `.otoxan-only` work, verify all changed paths are under `.otoxan/`:
+   - `git diff --name-status HEAD`
+   - `git diff --name-status --cached HEAD`
+8. Include in the PR:
+   - why the operating pack changed
+   - what future agent behavior changes
+   - changed files
+   - validation/readback evidence
+
+Do not use `.otoxan/` to hide task progress, stale PR numbers, or temporary session notes. Durable context belongs here; ephemeral execution status does not.

--- a/.otoxan/rules/agent-onboarding.md
+++ b/.otoxan/rules/agent-onboarding.md
@@ -1,0 +1,30 @@
+# Agent onboarding rule
+
+Before doing repo work, agents must build a current local picture of `bd-site` instead of relying only on memory or prior reports.
+
+Minimum onboarding read:
+
+1. `.otoxan/README.md`
+2. `.otoxan/context.md`
+3. `package.json`
+4. `README.md`
+5. `CLAUDE.md`
+6. `src/config.ts`
+7. `src/content.config.ts`
+8. `src/live.config.ts`
+9. The issue-specific files named by the task
+
+Then verify:
+
+```bash
+git status --short --branch
+pnpm --version
+node --version
+```
+
+Operational expectations:
+
+- Work in the canonical clone for this repo unless the task flow explicitly creates a separate worktree.
+- Do not assume repo docs are current when package scripts or source code say otherwise.
+- Treat this site as a personal-brand property. Product/content decisions need brand context, not just technical correctness.
+- If the task changes repo behavior, leave PR evidence that explains what future agents or humans should know.

--- a/.otoxan/rules/content-and-brand.md
+++ b/.otoxan/rules/content-and-brand.md
@@ -1,0 +1,69 @@
+# Content and brand rules
+
+This repo is Matt Berryhill's personal brand website. Treat content work as brand architecture, not filler generation.
+
+## Voice and positioning
+
+The brand should read as:
+
+- Specific enough to be useful and falsifiable.
+- Human, direct, and grounded.
+- Opinionated without pretending certainty where the facts are unsettled.
+- Technical when it matters, but not academic for its own sake.
+- Builder/operator oriented, not generic AI-news commentary.
+
+Avoid:
+
+- Generic AI influencer cadence.
+- Hype phrases without concrete examples.
+- Vague claims like "AI is changing everything" unless immediately grounded.
+- Over-polished corporate voice.
+- Content that could belong to any AI account.
+
+## Content schema
+
+Blog posts live under `src/data/blog/` as Markdown.
+
+Frontmatter commonly includes:
+
+- `title`
+- `description`
+- `pubDatetime`
+- `modDatetime`
+- `tags`
+- `featured`
+- `draft`
+- `ogImage`
+- `canonicalURL`
+- `hideEditPost`
+- `timezone`
+
+Rules:
+
+- Files starting with `_` are ignored by the loader.
+- `draft: true` hides posts from production lists.
+- Scheduled posts become visible after `pubDatetime` with the configured margin.
+- Global timezone is `Asia/Bangkok`; posts can override with `timezone`.
+- Do not publish under Matt's brand voice without preserving his positioning and review expectations.
+
+## Content API caution
+
+The repository has API docs and implementation for post management. Before changing or using the API, compare:
+
+- `API.md`
+- `src/pages/api/posts.ts`
+- `src/config.ts`
+
+Do not assume docs are perfectly current when behavior matters.
+
+## Strategic content fit
+
+Prefer changes that strengthen one of these lanes:
+
+- Agentic-first development.
+- AI/ML systems and automation.
+- Blockchain and crypto market analysis.
+- Digital music and creative systems.
+- Practical operating notes from building with agents.
+
+Every post or major page edit should answer: what perception shift does this create for Matt?

--- a/.otoxan/rules/docs-and-contributing.md
+++ b/.otoxan/rules/docs-and-contributing.md
@@ -1,0 +1,20 @@
+# Docs and contributing rule
+
+This repo has a mix of bd-site-specific docs and upstream AstroPaper-derived docs. Agents must check docs against source before treating them as executable truth.
+
+Known docs surfaces:
+
+- `README.md` — bd-site overview, local development, Docker/Helm/deployment notes.
+- `CLAUDE.md` — AI coding guide; useful, but some command descriptions may lag `package.json`.
+- `API.md` — API reference for post management; compare with `src/pages/api/posts.ts` before changing or using API behavior.
+- `.github/CONTRIBUTING.md` — contributor guide; may still reflect AstroPaper upstream defaults.
+- `.github/PULL_REQUEST_TEMPLATE.md` — PR template; use it, but add repo-specific validation evidence and path-boundary statement.
+- `LLM_CRAWL_MANIFEST.md` — LLM/SEO indexing strategy and crawl surfaces.
+- `helm/README.md` — deployment chart guidance.
+
+When updating docs:
+
+1. Identify the source file or behavior the doc describes.
+2. Verify the current implementation.
+3. Update docs and implementation together only when the issue scopes both.
+4. Keep PRs narrowly scoped and explain any docs/source mismatch resolved or intentionally left unresolved.

--- a/.otoxan/rules/github-issue-to-pr.md
+++ b/.otoxan/rules/github-issue-to-pr.md
@@ -1,0 +1,34 @@
+# GitHub issue to PR rule
+
+All material repo changes must follow this path:
+
+1. Create or identify a controlling GitHub issue.
+2. Resolve the repo base branch from GitHub metadata; default is `main`.
+3. Start from a clean worktree.
+4. Fetch/prune and fast-forward local `main` from `origin/main`.
+5. Create a feature/docs/fix branch that includes the issue number.
+6. Make only scoped changes for the issue.
+7. Stage specific files only. Do not use broad `git add -A` in agent flows.
+8. Inspect staged diff before commit:
+   - `git diff --stat --cached HEAD`
+   - `git diff --name-status --cached HEAD`
+9. Stop on unexpected source/config deletions or unrelated changes.
+10. Commit with a clear scoped message.
+11. Push branch and open a PR to `main`.
+12. Link PR to the issue and include validation evidence.
+
+Recommended branch names:
+
+- `.otoxan` or docs-only work: `docs/issue-N-short-slug`
+- Content work: `content/issue-N-short-slug`
+- App/source work: `feat/issue-N-short-slug` or `fix/issue-N-short-slug`
+
+PR body must state the path boundary:
+
+- `.otoxan-only`
+- docs-only
+- content-only
+- app/source-code-touching
+- deployment-touching
+
+Never claim a PR is ready without verifying the PR state and changed files through GitHub after opening it.

--- a/.otoxan/rules/no-embedded-wiki.md
+++ b/.otoxan/rules/no-embedded-wiki.md
@@ -1,0 +1,13 @@
+# Embedded wiki status
+
+At the time this pack was created, `berryhill/bd-site` does not have an embedded `wiki/` knowledge base requiring wiki index/log maintenance.
+
+If a future issue adds an embedded wiki or knowledge base:
+
+- Add explicit wiki instructions to `.otoxan/`.
+- Define where raw sources live and whether they are immutable.
+- Define where synthesized knowledge should be written.
+- Require index/log updates if the wiki uses them.
+- Route wiki mutations through issue -> branch -> PR.
+
+Until then, do not invent wiki paths or claim wiki update requirements for this repo. Use `.otoxan/` for durable agent operating context and existing repository docs for human-facing project documentation.

--- a/.otoxan/rules/safe-agent-work.md
+++ b/.otoxan/rules/safe-agent-work.md
@@ -1,0 +1,60 @@
+# Safe agent work rules
+
+## Commands
+
+Use `pnpm`, not npm or yarn, for normal repository work.
+
+Core validation commands:
+
+```bash
+pnpm run lint
+pnpm run format:check
+pnpm run build
+```
+
+There is no formal test script in `package.json` at the time this pack was created. Treat lint, format check, and build as the default validation suite unless a task introduces a more specific check.
+
+## Secrets and generated files
+
+Do not commit:
+
+- `.env`
+- `.env.prod`
+- Doppler tokens or service tokens
+- `helm/values.prod.yaml`
+- `.roo/mcp.json`
+- `dist/`
+- `.astro/`
+- `node_modules/`
+- `public/pagefind/`
+
+`X_API_KEY` is a server-side secret for API routes. Never print, paste, or commit real key values.
+
+## Code patterns
+
+- Prefer `@/*` imports for `src` paths.
+- Respect ESLint's `no-console` rule. Do not add `console.*` unless explicitly justified and suppressed.
+- Keep TypeScript/Astro changes compatible with strict config.
+- Do not assume static-site-only behavior; this repo uses server output and live content behavior.
+- Be careful with routes that set `prerender = false`; many dynamic routes depend on live collections.
+
+## Deployment cautions
+
+Deployment involves Docker, GHCR, Helm, and Doppler-backed runtime secrets.
+
+For deployment-touching changes, inspect both:
+
+- `.github/workflows/deploy.yaml`
+- `helm/values.yaml`
+
+Keep image tags and deployment assumptions synchronized when explicitly changing release/deploy behavior.
+
+Do not alter branch protection, GitHub Actions settings, repo secrets, webhooks, Doppler config, cluster config, or Helm production values unless Matt explicitly scopes that work.
+
+## Diff safety
+
+Before any commit, staged changes must be scoped to the controlling issue.
+
+For `.otoxan-only` work, changed paths should all begin with `.otoxan/`.
+For content-only work, changed paths should normally be under `src/data/blog/` plus narrowly required supporting assets/docs.
+For source work, include validation output in the PR.


### PR DESCRIPTION
## Summary

Adds a repo-local `.otoxan/` operating pack for `berryhill/bd-site`, so future agent work starts with repository-native context instead of relying only on external onboarding reports or memory.

This pack documents:

- bd-site identity and brand context for Matt Berryhill / berryhill.dev
- actual tech stack and important repo paths
- source-of-truth order when docs and implementation disagree
- issue -> branch -> PR workflow
- safe agent work rules for staging, validation, secrets, and deployment-sensitive changes
- content and brand rules for personal-brand edits
- reusable flows for GitHub issue-to-PR, code changes, content changes, and repo knowledge updates

## Changed files

- `.otoxan/README.md`
- `.otoxan/context.md`
- `.otoxan/rules/agent-onboarding.md`
- `.otoxan/rules/content-and-brand.md`
- `.otoxan/rules/docs-and-contributing.md`
- `.otoxan/rules/github-issue-to-pr.md`
- `.otoxan/rules/no-embedded-wiki.md`
- `.otoxan/rules/safe-agent-work.md`
- `.otoxan/flows/github-issue-to-pr.md`
- `.otoxan/flows/code-change.md`
- `.otoxan/flows/content-change.md`
- `.otoxan/flows/repo-knowledge-update.md`

## Path boundary

`.otoxan-only`.

No application source, blog content, deployment config, package manager config, or existing docs were changed.

## Validation

- Repo inspected for stack, docs, content patterns, CI/deploy files, and existing AI guidance.
- Branch created from fresh `main` after `git fetch --prune` and `git pull --ff-only origin main`.
- Staged diff checked before commit:
  - `git diff --stat --cached HEAD`: 12 `.otoxan/` files, 438 insertions.
  - `git diff --name-status --cached HEAD`: only `.otoxan/` paths.
- `pnpm run build`: passed.
- `pnpm run lint`: failed on pre-existing source lint errors outside this PR's `.otoxan-only` path boundary.
- `pnpm run format:check`: blocked in this environment by pnpm build-script approval policy; no repo-level pnpm policy file is included in this PR.

## Future agent behavior changed

Future agents should read `.otoxan/` before modifying this repo, classify path boundaries explicitly, route repo mutations through issue -> branch -> PR, and treat bd-site as Matt's personal-brand surface rather than a generic AstroPaper install.

Closes #1
