### PR TITLE
Fix Docker pnpm build approval policy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ WORKDIR /app
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Copy package files
-COPY package.json pnpm-lock.yaml ./
+# Copy package files and pnpm build-approval policy
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 
 # Copy source and build
@@ -31,8 +31,8 @@ RUN apk add --no-cache ca-certificates && \
 # Install pnpm
 RUN corepack enable && corepack prepare pnpm@latest --activate
 
-# Copy package files and install production deps only
-COPY package.json pnpm-lock.yaml ./
+# Copy package files and pnpm build-approval policy, then install production deps only
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 RUN pnpm install --prod --frozen-lockfile
 
 # Copy built application from build stage

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+# Approved install-time build scripts required by Astro/Tailwind/image tooling.
+allowBuilds:
+  "@tailwindcss/oxide": true
+  esbuild: true
+  sharp: true


### PR DESCRIPTION
## Controlling issue

Part of #3: Umbrella: establish CI baseline

## Phase scope

Phase 1 fixes the Docker/pnpm install path for deployment builds by committing an explicit pnpm build-approval policy and making both Docker install stages copy that policy before `pnpm install`.

This is a narrow deployment/package-manager PR. It does not change site content, routes, Helm values, secrets, or runtime application logic.

## Changed files

- `Dockerfile`
  - Copies `pnpm-workspace.yaml` alongside `package.json` and `pnpm-lock.yaml` before the build-stage install.
  - Copies the same policy before the runtime-stage production install.
- `pnpm-workspace.yaml`
  - Adds `allowBuilds` approvals for the native packages required by the current Astro/Tailwind/image stack: `@tailwindcss/oxide`, `esbuild`, and `sharp`.

## Validation evidence

Environment readback:

- `pnpm --version` => `11.1.3`
- `node --version` => `v22.22.3`
- branch => `luca/phase-1-docker-pnpm-deploy-fix`
- base => `main`

Diff guards before push:

- `git diff --name-status origin/main...HEAD` => `M Dockerfile`, `A pnpm-workspace.yaml`
- `git diff --stat origin/main...HEAD` => 2 files changed, 9 insertions(+), 4 deletions(-)
- `git diff --check origin/main...HEAD` => no whitespace errors

Validation commands:

- `pnpm run build` => passed
- `pnpm run lint` => failed on existing repo baseline lint errors outside this PR scope, including pre-existing Astro parser/no-console/no-unused-vars findings in `src/components/Card.astro`, `src/layouts/Layout.astro`, `src/pages/api/posts.ts`, route files, `src/utils/indexnow.ts`, and `test-upload.js`.
- `pnpm run format:check` => failed on existing repo baseline formatting/parser issues outside this PR scope, including `.github/workflows/deploy.yaml`, `package.json`, `README.md`, multiple Astro/source files, and parser errors in `src/layouts/Layout.astro` and `src/pages/index.astro`.

## Path boundary

deployment-touching

Touched paths are limited to:

- `Dockerfile`
- `pnpm-workspace.yaml`

## Residual risks / counsel questions

- This PR intentionally does not clean up the broader lint/format baseline; that belongs in later CI-baseline phases so the deployment fix stays reviewable.
- The committed policy approves only the native build scripts observed as necessary for the current stack. If future dependency changes add native build scripts, pnpm may require a follow-up policy update.
- Docker image build itself should be confirmed by GitHub Actions or a dedicated Docker validation pass after PR creation if runner/runtime parity is the acceptance gate.