### PR TITLE
Document CI baseline and install policy in .otoxan

### DIFF
--- a/.otoxan/README.md
+++ b/.otoxan/README.md
@@ -26,6 +26,8 @@ Canonical repo/base branch:
 - Base branch: `main`
 - Package manager: `pnpm`
 - Validation suite: `pnpm run lint`, `pnpm run format:check`, `pnpm run build`
+- CI runtime: Node 20 with pnpm 10.11.1
+- Current build script: `astro build`
 
 Boundary for this pack:
 

--- a/.otoxan/context.md
+++ b/.otoxan/context.md
@@ -50,6 +50,9 @@ When docs disagree, prefer this order:
 Known cautions:
 
 - `package.json` currently defines `build` as `astro build`; do not assume extra `astro check` or Pagefind copy steps unless the script is changed.
+- Current CI uses Node 20, pnpm 10.11.1, `pnpm install`, `pnpm run lint`, `pnpm run format:check`, and `pnpm run build`. Do not assume `--frozen-lockfile`, `astro check`, or Pagefind indexing in CI unless the workflow changes.
+- Docker builds intentionally use `pnpm install --frozen-lockfile` in both build and runtime stages. Keep Docker lockfile policy separate from CI's install policy.
+- `pnpm-workspace.yaml` is present to approve install-time build scripts required by `@tailwindcss/oxide`, `esbuild`, and `sharp`; do not remove it as unrelated workspace noise.
 - Some upstream AstroPaper docs/templates remain in `.github/` and may not be fully bd-site-specific.
 - `API.md` and `src/pages/api/posts.ts` should be compared before API changes; docs and implementation have had shape/base-URL mismatches.
 - `src/config.ts` edit URL currently references `berryhilldev/bd-site`; verify repo owner paths before changing public edit links.

--- a/.otoxan/rules/docs-and-contributing.md
+++ b/.otoxan/rules/docs-and-contributing.md
@@ -5,7 +5,7 @@ This repo has a mix of bd-site-specific docs and upstream AstroPaper-derived doc
 Known docs surfaces:
 
 - `README.md` — bd-site overview, local development, Docker/Helm/deployment notes.
-- `CLAUDE.md` — AI coding guide; useful, but some command descriptions may lag `package.json`.
+- `CLAUDE.md` — AI coding guide; useful, but some command descriptions may lag `package.json` and CI. In particular, verify any claims about `astro check`, Pagefind indexing, or build sequencing against `package.json` and `.github/workflows/ci.yml` before treating them as current.
 - `API.md` — API reference for post management; compare with `src/pages/api/posts.ts` before changing or using API behavior.
 - `.github/CONTRIBUTING.md` — contributor guide; may still reflect AstroPaper upstream defaults.
 - `.github/PULL_REQUEST_TEMPLATE.md` — PR template; use it, but add repo-specific validation evidence and path-boundary statement.
@@ -18,3 +18,5 @@ When updating docs:
 2. Verify the current implementation.
 3. Update docs and implementation together only when the issue scopes both.
 4. Keep PRs narrowly scoped and explain any docs/source mismatch resolved or intentionally left unresolved.
+
+Current known mismatch to preserve unless explicitly scoped: `package.json` defines `build` as `astro build`, while older guidance may describe a larger build pipeline with `astro check` and Pagefind indexing. Treat source/config as authoritative and note the mismatch rather than broadening unrelated PRs.

--- a/.otoxan/rules/safe-agent-work.md
+++ b/.otoxan/rules/safe-agent-work.md
@@ -14,6 +14,20 @@ pnpm run build
 
 There is no formal test script in `package.json` at the time this pack was created. Treat lint, format check, and build as the default validation suite unless a task introduces a more specific check.
 
+## CI and package-manager baseline
+
+The current pull-request CI baseline is intentionally narrow and should be treated as the reviewer-facing validation contract:
+
+- GitHub Actions runs on Node 20.
+- CI installs pnpm 10.11.1.
+- CI runs `pnpm install` without `--frozen-lockfile`.
+- CI then runs `pnpm run lint`, `pnpm run format:check`, and `pnpm run build`.
+- `pnpm run build` currently maps to `astro build`; it does not run `astro check` or Pagefind indexing unless `package.json` changes.
+
+Docker is stricter than CI by design: the Dockerfile uses `pnpm install --frozen-lockfile` in build/runtime stages. Do not “fix” CI by copying Docker's frozen-lockfile policy unless the issue explicitly scopes that change.
+
+`pnpm-workspace.yaml` is a required package-manager policy file here. It approves native/install-time build scripts for `@tailwindcss/oxide`, `esbuild`, and `sharp`; removing it can reintroduce `ERR_PNPM_IGNORED_BUILDS` in Docker or CI-like installs.
+
 ## Secrets and generated files
 
 Do not commit:


### PR DESCRIPTION
## Controlling issue

Part of #3: Umbrella: establish CI baseline

## Phase scope

Phase 3 documents CI operating guidance in the `.otoxan/` operating pack. This is a narrow `.otoxan-only` PR that captures:

- CI runtime: Node 20, pnpm 10.11.1
- CI install policy: `pnpm install` (no `--frozen-lockfile`)
- Build script behavior: `astro build` only — no `astro check` or Pagefind indexing in CI
- Docker lockfile distinction: frozen-lockfile in both build and runtime stages
- `pnpm-workspace.yaml` purpose: approves native build scripts for `@tailwindcss/oxide`, `esbuild`, and `sharp`
- Known docs/source mismatch: build pipeline description in older docs vs `package.json` and `ci.yml`

## Changed files

- `.otoxan/README.md` — CI runtime and build script note
- `.otoxan/context.md` — CI install policy, Docker lockfile distinction, pnpm-workspace.yaml note
- `.otoxan/rules/docs-and-contributing.md` — build pipeline mismatch caution
- `.otoxan/rules/safe-agent-work.md` — CI baseline section with install policy and Docker vs CI distinction

## Path boundary

`.otoxan-only`

## Validation evidence

Environment:
- `pnpm --version` => 11.1.3
- `node --version` => v22.22.3
- Branch base: `origin/main`

Diff guards before commit:
- `git diff --stat --cached HEAD` => 4 files, 22 insertions(+), 1 deletion(-)
- `git diff --name-status --cached HEAD` => only `.otoxan/` paths

Validation commands (all passed):
- `pnpm run lint` => passed (eslint .)
- `pnpm run format:check` => passed (All matched files use Prettier code style!)
- `pnpm run build` => passed (astro build, server build complete)
