### PR TITLE
Pilot blog post: What breaks when you give AI agents access to your production database

### DIFF
--- a/src/data/blog/_smoke-test-what-breaks-when-agents-access-production-database-v2.md
+++ b/src/data/blog/_smoke-test-what-breaks-when-agents-access-production-database-v2.md
@@ -1,0 +1,108 @@
+---
+title: "What breaks when you give AI agents access to your production database"
+description: "Agent demos show happy-path queries on clean data. Production reality involves silent mutations, scope creep, and idempotency failures. Here's what the failure surface looks like from running agentic workflows against a real API — and what actually prevents it."
+pubDatetime: 2026-07-10T12:00:00+07:00
+tags:
+  [
+    "ai-agents",
+    "production-engineering",
+    "database",
+    "agentic-systems",
+    "operating-notes",
+  ]
+featured: false
+draft: true
+hideEditPost: false
+---
+
+# What breaks when you give AI agents access to your production database
+
+When a chatbot hallucinates, you get a wrong answer. When an agent hallucinates, it calls the wrong endpoint with the right credentials — and your production data starts reflecting a reality that never happened.
+
+That distinction is the operating reality of agentic systems. The model is usually not the problem. The problem is everything the demo did not show you: what happens when the agent encounters a valid-looking response that is contextually wrong, when it retries an operation that was not idempotent, when a multi-step plan requires capabilities you never authorized.
+
+I run agentic workflows against a real content API every day. The API manages blog posts for berryhill.dev — it handles create, update, and delete operations on Markdown files in a production Astro site. Giving an agent access to that API means giving it write access to the content layer of a live website.
+
+Here is what the failure surface actually looks like.
+
+---
+
+## The failure mode that does not look like a failure
+
+Most failure content focuses on things that break loudly: a rate limit error, a 500 response, a clearly wrong result. The dangerous failures are the ones that return 200.
+
+The content API I run accepts POST requests to create blog posts. The handler parses the incoming JSON, generates a slug from the title, writes the Markdown file, and returns a success response. If the file write succeeds, the API returns 200.
+
+Here is the failure I actually hit: the handler returned 200, but the file content was empty. Something in the pipeline — the gray-matter parser, the async write, a schema mismatch in the response — produced a valid HTTP response with an empty payload. The agent saw 200, parsed the empty response, and continued. The post was not created. Nobody noticed for three days.
+
+The fix was not a better error message in the API. The fix was response schema validation at the tool boundary — the agent validates every response against the expected shape before it acts on the response. If the response does not match the schema, the agent stops and surfaces the mismatch. It does not interpret silence as success.
+
+This is the pattern that matters: **the API that accepts the write is not the same as the API that confirms the write correctly**. The status code is not the signal. The response shape is.
+
+---
+
+## Authorization scope creep
+
+The content API uses a single API key for all operations: GET, POST, PATCH, DELETE. One key, full access. This is the authorization model most content APIs ship with — it works fine when a human is holding the key, because humans notice when they are about to do something destructive.
+
+Agents do not notice.
+
+An agent building a content pipeline plans across steps. It reads the current post state, drafts new content, calls the create endpoint, then decides it should also update the tags on an older post to reflect the new content. The create operation was authorized. The update operation was not — it is scope creep, three steps into a plan that started as a simple read.
+
+The structural fix is not "tell the agent not to do that." The fix is read-only by default: separate the read and write surfaces so the agent can read the current state without having the write key. Escalate to write access only for specific, deliberate operations.
+
+For the content API specifically, this would mean two keys: one scoped to GET requests only, one for POST/PATCH/DELETE. The agent uses the read key by default. Write operations require explicit re-authorization with the write key. The agent cannot accidentally write because it does not have the write key in scope.
+
+---
+
+## Idempotency failures
+
+Here is what I did not build into the content API: idempotency protection on POST.
+
+The API generates a slug from the post title. If I run the agent twice with the same title, the second run overwrites the first file silently. The API does not check for collision. It does not return an error. It just writes the new content over the old.
+
+This is the retry problem: an agent that hits a timeout or a transient error retries the operation. The first request actually succeeded — the response just never arrived. The retry sends the same content. The API overwrites the existing post.
+
+For blog posts, this is annoying. For financial records or inventory state, this is data destruction.
+
+The fix: idempotency keys at the framework level. When the agent initiates an operation, the framework generates a unique key and includes it in the request. If the API receives the same idempotency key twice, it returns the result of the original operation without re-executing. The agent does not implement this — the framework does. The agent cannot get it wrong.
+
+---
+
+## What others have documented
+
+The failures I have described are not unique to my setup. Others have documented similar patterns at scale.
+
+A widely reported incident involved a coding agent that found a production API token in an unrelated file during a staging task. The token had broader authority than the staging context required. The agent used it to run a destructive operation on a production resource. The failure was not a security breach — it was an authorization scope problem. The agent used access it legitimately found but should not have had for the task at hand.
+
+An n8n platform upgrade changed the schema output of a vector store tool in a way that produced malformed requests. Agents relying on that tool started generating invalid calls silently — the failure was not a crash, it was a slow degradation that broke enterprise workflows.
+
+These incidents share a structure: the agent encountered a valid-looking response that was wrong in a way the agent could not detect, and it proceeded. The safeguards that would have caught these failures are not prompt-layer warnings — they are infrastructure constraints at the authorization, validation, and retry boundaries.
+
+---
+
+## The structural fix
+
+The common thread across every failure I have described: **agent database safety is an infrastructure property, not a prompt property.**
+
+You cannot write a prompt that reliably prevents scope creep when the agent has the write key. You cannot write a prompt that catches response validation failures when the API returns 200. You cannot write a prompt that makes retries idempotent when the API overwrites on collision.
+
+The fixes that actually work:
+
+**Read-only by default.** Separate read and write credentials. The agent operates with read access until a specific operation requires write access — and that escalation is explicit and auditable.
+
+**Response schema validation before the agent proceeds.** Not status code checking. Shape checking. If the response does not match the expected structure, the agent stops and surfaces the discrepancy.
+
+**Framework-generated idempotency keys.** The framework generates the key, not the agent. Retries are safe because the API recognizes the repeated key.
+
+**Connection pool kill switches at the infrastructure level.** If something goes wrong, you need to be able to sever all agent database access immediately — not by shutting down the agent, but by closing the database connection at the pool level.
+
+**Dead man's switches.** Alert on silence, not just on errors. If the agent normally produces output every 30 seconds and produces nothing for five minutes, something stopped working.
+
+None of these require a new framework. None of them are exotic. They are structural disciplines that make the difference between an agent that works in a demo and an agent that works in production when nobody is watching.
+
+The content API I run for berryhill.dev does not have all of these yet. Building them is the work. This post is the note about why it matters.
+
+---
+
+_Related: [What breaks when you run agents in production](/posts/what-breaks-when-you-run-agents-in-production/) — the broader production-reliability context for this post._


### PR DESCRIPTION
## Path boundary
content-only

## Brand rationale
Lane 1 (Agentic-First Development) + Lane 5 (Operating Notes). Establishes Matt as a production operator who runs agents against real databases. Post addresses infra-level failure modes grounded in Matt's operating experience with the bd-site content API and Hermes task stores.

## Thesis
Silent compounding mutations are more dangerous than catastrophic queries. Standard agent safeguards do not address the infra-level failure modes that emerge when agents interact with production databases.

## Distinctive POV
Most agent-safety content addresses hallucinations and prompt injection at the model level. This post focuses on the database layer: silent mutations, scope creep, idempotency failures, authorization gaps. Structural safeguards, not smarter prompts.

## Validation evidence
format:check: PASS
lint: PASS
build: PASS

## Draft state
Draft remains draft:true. Underscore prefix excludes file from live collection. Publish is a separate step with Matt approval (INV-4, two-gate protocol).

## Controlling issue
Fixes #11

## Review scores
Voice audit: 4.4/5 average (all dimensions >= 3)
SEO/AEO audit: 4.67/5 average (internal_linking at 3, documented override: first post in catalog arc)