### PR TITLE
Hide public edit affordance

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -12,9 +12,10 @@ export const SITE = {
   showArchives: true,
   showBackButton: true, // show back button in post detail
   editPost: {
-    enabled: true,
-    text: "Edit page",
-    url: "https://github.com/berryhilldev/bd-site/edit/main/",
+    // Keep the public brand surface focused on readers, not upstream theme maintenance.
+    enabled: false,
+    text: "Suggest a correction",
+    url: "https://github.com/berryhill/bd-site/edit/main/",
   },
   dynamicOgImage: true,
   dir: "ltr", // "rtl" | "auto"


### PR DESCRIPTION
## Description

Hides the public blog-post edit affordance by disabling `SITE.editPost` globally. The fallback label is reframed from the upstream/theme-like "Edit page" to "Suggest a correction" in case the affordance is intentionally re-enabled later, and the repo URL now points at the canonical `berryhill/bd-site` path.

This keeps berryhill.dev focused as Matt's reader-facing brand surface instead of exposing a generic upstream maintenance link on posts.

Path boundary: app/source-code-touching

## Types of changes

- [x] Bug Fix (non-breaking change which fixes an issue)
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Documentation Update (if none of the other choices apply)
- [ ] Others (any other types not listed above)

## Checklist

- [x] Scoped to issue #16
- [x] Staged only `src/config.ts`
- [x] No secrets or generated files committed
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)

## Validation

- `pnpm run lint` — pass
- `pnpm exec prettier --check src/config.ts` — pass
- `pnpm run build` — pass
- `pnpm run format:check` — fails on pre-existing untracked/content files outside this PR scope; `src/config.ts` passes targeted Prettier check
- Built server bundle search shows `SITE.editPost.enabled` is `false`; no `Edit page` or old `berryhilldev/bd-site` string remains in `dist` search output.

## Further comments

The worktree already contained unrelated dirty/untracked files before this branch. This PR commits only the one scoped source file required for issue #16.

## Related Issue

Closes: #16
