### PR TITLE
Add durable blog visual asset validation

### DIFF
--- a/.otoxan/context.md
+++ b/.otoxan/context.md
@@ -27,7 +27,9 @@ Verified from repository files during onboarding:
 - `src/content.config.ts` — exports `BLOG_PATH`; live collections are defined elsewhere.
 - `src/live.config.ts` — live blog collection wiring.
 - `src/loaders/filesystem.ts` — custom recursive Markdown loader.
+- `src/utils/blogVisualAssets.ts` — validation for durable local blog visual references.
 - `src/data/blog/` — Markdown blog posts.
+- `public/assets/blog/<post-slug>/` — stable durable location for repo-backed blog visuals referenced as `/assets/blog/<post-slug>/...`.
 - `src/pages/api/posts.ts` — content API for post create/update/delete.
 - `src/pages/about.md` — about page content.
 - `.github/workflows/ci.yml` — CI validation.
@@ -55,6 +57,7 @@ Known cautions:
 - `pnpm-workspace.yaml` is present to approve install-time build scripts required by `@tailwindcss/oxide`, `esbuild`, and `sharp`; do not remove it as unrelated workspace noise.
 - Some upstream AstroPaper docs/templates remain in `.github/` and may not be fully bd-site-specific.
 - `API.md` and `src/pages/api/posts.ts` should be compared before API changes; docs and implementation have had shape/base-URL mismatches.
+- Blog visual references are enforced by both the filesystem loader and POST/PATCH API paths through `src/utils/blogVisualAssets.ts`; inline `data:image` URIs are rejected and local `/assets/blog/<post-slug>/...` references must have backing files plus alt text and caption/title.
 - `src/config.ts` edit URL currently references `berryhilldev/bd-site`; verify repo owner paths before changing public edit links.
 
 ## Brand frame

--- a/.otoxan/rules/content-and-brand.md
+++ b/.otoxan/rules/content-and-brand.md
@@ -46,6 +46,10 @@ Rules:
 - Global timezone is `Asia/Bangkok`; posts can override with `timezone`.
 - Do not publish under Matt's brand voice without preserving his positioning and review expectations.
 
+### Blog visual assets
+
+Diagrams should be real process artifacts or sourced/non-generative visuals, not generic AI stock tropes. Store durable repo-backed blog visuals under `public/assets/blog/<post-slug>/`, reference them in Markdown as `/assets/blog/<post-slug>/filename.svg` or `.png`, and include useful alt text plus a caption/title. Inline `data:image` URIs are forbidden.
+
 ## Content API caution
 
 The repository has API docs and implementation for post management. Before changing or using the API, compare:

--- a/.otoxan/rules/safe-agent-work.md
+++ b/.otoxan/rules/safe-agent-work.md
@@ -7,12 +7,13 @@ Use `pnpm`, not npm or yarn, for normal repository work.
 Core validation commands:
 
 ```bash
+pnpm test
 pnpm run lint
 pnpm run format:check
 pnpm run build
 ```
 
-There is no formal test script in `package.json` at the time this pack was created. Treat lint, format check, and build as the default validation suite unless a task introduces a more specific check.
+`package.json` includes a scoped unit test script. Treat test, lint, format check, and build as the default validation suite unless a task narrows or expands validation.
 
 ## CI and package-manager baseline
 
@@ -41,6 +42,8 @@ Do not commit:
 - `.astro/`
 - `node_modules/`
 - `public/pagefind/`
+
+`public/assets/blog/` is commit-eligible source asset space for durable blog visuals; do not treat it like generated `dist/` or `public/pagefind/` output.
 
 `X_API_KEY` is a server-side secret for API routes. Never print, paste, or commit real key values.
 

--- a/API.md
+++ b/API.md
@@ -170,6 +170,8 @@ Content-Type: application/json
 - `hideEditPost` (optional): Hide the edit link for this post
 - `timezone` (optional): IANA timezone override for datetime display
 
+**Content image references:** POST `content` may include normal external images. Repo-backed blog visuals must be referenced as `/assets/blog/<slug>/filename.svg` or `/assets/blog/<slug>/filename.png`, include alt text plus a caption/title in Markdown, and have an existing backing file under `public/assets/blog/<slug>/`. Inline `data:image` URIs are invalid.
+
 **Response (201 Created):**
 ```json
 {
@@ -231,6 +233,8 @@ Content-Type: application/json
 - `hideEditPost` (optional): Update whether the edit link is hidden
 - `timezone` (optional): Update IANA timezone override
 - `content` (optional): Update post content in Markdown
+
+**Content image references:** PATCH `content` may include normal external images. Repo-backed blog visuals must be referenced as `/assets/blog/<slug>/filename.svg` or `/assets/blog/<slug>/filename.png`, include alt text plus a caption/title in Markdown, and have an existing backing file under `public/assets/blog/<slug>/`. Inline `data:image` URIs are invalid.
 
 **Response (200 OK):**
 ```json
@@ -325,6 +329,20 @@ or
 ```json
 {
   "error": "Missing required parameter: [parameter_name]"
+}
+```
+
+Endpoint-specific validation failures may also return:
+
+```json
+{
+  "error": "Invalid blog visual asset reference",
+  "details": [
+    {
+      "src": "/assets/blog/my-post-slug/diagram.svg",
+      "reason": "Missing caption/title for local blog visual"
+    }
+  ]
 }
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ pnpm install
 # Start development server (runs on localhost:4321)
 pnpm run dev
 
-# Build for production (includes Astro check, build, and Pagefind indexing)
+# Build for production (package.json maps this to astro build)
 pnpm run build
 
 # Preview production build
@@ -25,6 +25,7 @@ pnpm run preview
 pnpm run sync        # Generate TypeScript types for Astro modules
 
 # Code quality
+pnpm test           # Run scoped unit tests
 pnpm run lint        # Run ESLint
 pnpm run format      # Format code with Prettier
 pnpm run format:check # Check formatting without writing
@@ -38,6 +39,7 @@ pnpm run format:check # Check formatting without writing
 - **Content Schema**: Defined in [src/content.config.ts](src/content.config.ts) using Astro's content collections API
 - **Post Filtering**: Posts with `draft: true` are hidden in production. Posts can be scheduled with `pubDatetime` and will appear after the scheduled time (with a 15-minute margin defined in `SITE.scheduledPostMargin`)
 - **Frontmatter**: Posts use YAML frontmatter with fields like `title`, `description`, `pubDatetime`, `modDatetime`, `tags`, `featured`, `draft`, `ogImage`, `canonicalURL`, `hideEditPost`, `timezone`
+- **Durable Blog Visuals**: Store repo-backed diagrams/assets under `public/assets/blog/<post-slug>/` and reference them from Markdown as `/assets/blog/<post-slug>/filename.svg` or `.png` with alt text and a caption/title. Inline `data:image` URIs are rejected.
 
 ### Routing Structure
 
@@ -94,11 +96,7 @@ import getSortedPosts from "@/utils/getSortedPosts";
 
 ### Build Process
 
-The build command runs these steps sequentially:
-1. `astro check` - Type checking
-2. `astro build` - Build static site to `dist/`
-3. `pagefind --site dist` - Generate search index
-4. `cp -r dist/pagefind public/` - Copy search index to public directory
+`pnpm run build` currently maps to `astro build` in `package.json`.
 
 ### Search Functionality
 
@@ -122,6 +120,7 @@ Search is powered by Pagefind, which indexes the built site and provides client-
 
 - The project uses pnpm as the package manager
 - Blog posts with filenames starting with `_` are ignored by the glob loader pattern
+- Durable local blog visuals must use normal Markdown image syntax with alt text and caption/title; do not inline `data:image` URIs.
 - Posts are timezone-aware; global timezone is set in `SITE.timezone` (IANA format), individual posts can override with frontmatter `timezone`
 - The edit post feature links to a GitHub repository URL (configurable in `SITE.editPost`)
 - Archives page visibility is controlled by `SITE.showArchives` in the sitemap filter

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ This site runs as a server-side rendered (SSR) Astro application:
 │   ├── pages/              # Routes and API endpoints
 │   ├── styles/             # Global CSS and typography
 │   └── utils/              # Utility functions
+├── public/assets/blog/      # Durable blog visuals by post slug
 ├── Dockerfile              # Multi-stage Docker build for SSR
 ├── nginx.conf              # NGINX config (for reference)
 └── astro.config.ts         # Astro SSR configuration
@@ -94,7 +95,8 @@ pnpm run preview
 # Type checking
 pnpm run sync
 
-# Linting and formatting
+# Unit tests, linting, and formatting
+pnpm test
 pnpm run lint
 pnpm run format
 ```
@@ -168,6 +170,8 @@ NODE_ENV=production
 
 Blog posts are stored as Markdown files in `src/data/blog/`. In production, the posts directory is mounted as a PersistentVolume, allowing content updates without rebuilding the container.
 
+Durable local blog visuals belong under `public/assets/blog/<post-slug>/` and should be referenced from Markdown as `/assets/blog/<post-slug>/filename.svg` or `/assets/blog/<post-slug>/filename.png`. Use normal Markdown image syntax with useful alt text and a caption/title; inline `data:image` URIs are rejected.
+
 To update blog content in production:
 
 1. Content is stored on the PVC `bd-site-posts-pvc`
@@ -188,6 +192,7 @@ GitHub Actions workflow (`.github/workflows/deploy.yaml`):
 - Zero-downtime rolling deployments
 - Automatic TLS certificate management
 - Persistent blog content storage
+- Durable repo-backed blog visuals under `/assets/blog/<post-slug>/`
 - Terminal-style typing animations
 - Interactive pillar modals
 - Dark/light mode toggle

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
+    "test": "node tests/blogVisualAssets.test.mjs",
     "preview": "astro preview",
     "sync": "astro sync",
     "astro": "astro",

--- a/src/loaders/filesystem.ts
+++ b/src/loaders/filesystem.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
+import { assertValidBlogVisualAssets } from "@/utils/blogVisualAssets";
 
 export interface FilesystemLoaderOptions {
   baseDir: string;
@@ -50,6 +51,11 @@ export function filesystemLoader(options: FilesystemLoaderOptions) {
               // Generate ID from file path relative to base directory
               const relativePath = path.relative(fullPath, itemPath);
               const id = relativePath.replace(/\.md$/, "");
+
+              assertValidBlogVisualAssets(content, {
+                postSlug: id,
+                publicDir: path.resolve("public"),
+              });
 
               const entry = {
                 id,
@@ -104,6 +110,11 @@ export function filesystemLoader(options: FilesystemLoaderOptions) {
           // Read and parse the file
           const fileContent = await fs.readFile(filePath, "utf-8");
           const { data, content } = matter(fileContent);
+
+          assertValidBlogVisualAssets(content, {
+            postSlug: filter,
+            publicDir: path.resolve("public"),
+          });
 
           return {
             entry: {

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -6,6 +6,7 @@ import matter from "gray-matter";
 import { submitToIndexNow } from "@/utils/indexnow";
 import { SITE } from "@/config";
 import { requireApiKey } from "@/utils/apiAuth";
+import { validateBlogVisualAssets } from "@/utils/blogVisualAssets";
 
 export const prerender = false;
 
@@ -36,6 +37,28 @@ const applyOptionalFrontmatter = (
   if (value !== undefined) {
     frontmatterData[key] = value;
   }
+};
+
+const blogVisualValidationErrorResponse = (content: string, slug: string) => {
+  const result = validateBlogVisualAssets(content, {
+    postSlug: slug,
+    publicDir: join(process.cwd(), "public"),
+  });
+
+  if (result.valid) {
+    return null;
+  }
+
+  return new Response(
+    JSON.stringify({
+      error: "Invalid blog visual asset reference",
+      details: result.issues,
+    }),
+    {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    }
+  );
 };
 
 type PostRecord = Record<string, unknown> & {
@@ -208,6 +231,9 @@ export const POST: APIRoute = async context => {
 
     // Generate slug from title
     const slug = slugifyStr(title);
+
+    const validationError = blogVisualValidationErrorResponse(content, slug);
+    if (validationError) return validationError;
 
     // Generate filename
     const filename = `${slug}.md`;
@@ -417,6 +443,12 @@ export const PATCH: APIRoute = async context => {
 
     // Use updated content if provided, otherwise keep original
     const updatedContent = content !== undefined ? content : originalContent;
+
+    const validationError = blogVisualValidationErrorResponse(
+      updatedContent,
+      slug
+    );
+    if (validationError) return validationError;
 
     // Rebuild the file with updated frontmatter and content
     const updatedFile = matter.stringify(updatedContent, frontmatterData);

--- a/src/utils/blogVisualAssets.ts
+++ b/src/utils/blogVisualAssets.ts
@@ -1,0 +1,177 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export interface BlogVisualAssetValidationOptions {
+  postSlug: string;
+  publicDir?: string;
+}
+
+export interface BlogImageReference {
+  src: string;
+  altText: string;
+  caption: string;
+  source: "markdown" | "html";
+}
+
+export interface BlogVisualAssetIssue {
+  src: string;
+  reason: string;
+}
+
+export interface BlogVisualAssetValidationResult {
+  valid: boolean;
+  issues: BlogVisualAssetIssue[];
+}
+
+const MARKDOWN_IMAGE_REGEX =
+  /!\[([^\]]*)\]\(([^\s)]+)(?:\s+["']([^"']*)["'])?\)/g;
+const HTML_IMAGE_REGEX = /<img\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi;
+const BLOG_ASSET_PUBLIC_PREFIX = "/assets/blog/";
+
+function getAttribute(tag: string, name: string): string {
+  const attributeRegex = new RegExp(`\\b${name}=["']([^"']*)["']`, "i");
+  return attributeRegex.exec(tag)?.[1]?.trim() ?? "";
+}
+
+function isBlogVisualAsset(src: string): boolean {
+  return src.startsWith(BLOG_ASSET_PUBLIC_PREFIX);
+}
+
+function hasUnsafePathSegment(src: string): boolean {
+  return src.split(/[\\/]/).some(segment => segment === "..");
+}
+
+export function extractBlogImageReferences(
+  markdown: string
+): BlogImageReference[] {
+  const references = new Map<string, BlogImageReference>();
+
+  for (const match of markdown.matchAll(MARKDOWN_IMAGE_REGEX)) {
+    const src = match[2].trim();
+    references.set(`markdown:${src}`, {
+      src,
+      altText: match[1].trim(),
+      caption: match[3]?.trim() ?? "",
+      source: "markdown",
+    });
+  }
+
+  for (const match of markdown.matchAll(HTML_IMAGE_REGEX)) {
+    const tag = match[0];
+    const src = match[1].trim();
+    references.set(`html:${src}`, {
+      src,
+      altText: getAttribute(tag, "alt"),
+      caption: getAttribute(tag, "title"),
+      source: "html",
+    });
+  }
+
+  return [...references.values()];
+}
+
+export function extractBlogImageSources(markdown: string): string[] {
+  return [
+    ...new Set(extractBlogImageReferences(markdown).map(({ src }) => src)),
+  ];
+}
+
+export function isInlineImageDataUri(src: string): boolean {
+  return /^data:image\//i.test(src.trim());
+}
+
+export function validateBlogVisualAssets(
+  markdown: string,
+  options: BlogVisualAssetValidationOptions
+): BlogVisualAssetValidationResult {
+  const issues: BlogVisualAssetIssue[] = [];
+  const publicDir = options.publicDir ?? path.resolve("public");
+
+  for (const reference of extractBlogImageReferences(markdown)) {
+    const { src } = reference;
+
+    if (isInlineImageDataUri(src)) {
+      issues.push({
+        src,
+        reason:
+          "Inline data:image URIs are not allowed. Store durable blog visuals under public/assets/blog/<post-slug>/ and reference them with a normal /assets/blog/<post-slug>/... URL.",
+      });
+      continue;
+    }
+
+    if (!isBlogVisualAsset(src)) {
+      continue;
+    }
+
+    const expectedPrefix = `${BLOG_ASSET_PUBLIC_PREFIX}${options.postSlug}/`;
+
+    if (!src.startsWith(expectedPrefix)) {
+      issues.push({
+        src,
+        reason: `Blog visual assets must live under ${expectedPrefix} for this post.`,
+      });
+      continue;
+    }
+
+    if (hasUnsafePathSegment(src)) {
+      issues.push({
+        src,
+        reason:
+          "Blog visual asset paths cannot include parent-directory segments.",
+      });
+      continue;
+    }
+
+    if (!reference.altText) {
+      issues.push({
+        src,
+        reason: "Blog visual assets require non-empty alt text.",
+      });
+    }
+
+    if (!reference.caption) {
+      issues.push({
+        src,
+        reason:
+          'Blog visual assets require a caption/title in the Markdown image reference, for example: ![Alt text](/assets/blog/post/diagram.svg "Caption text").',
+      });
+    }
+
+    const assetPath = path.resolve(publicDir, `.${src}`);
+    const publicRoot = path.resolve(publicDir);
+
+    if (!assetPath.startsWith(`${publicRoot}${path.sep}`)) {
+      issues.push({
+        src,
+        reason: "Blog visual asset path resolves outside public/.",
+      });
+      continue;
+    }
+
+    if (!fs.existsSync(assetPath) || !fs.statSync(assetPath).isFile()) {
+      issues.push({
+        src,
+        reason: `Referenced blog visual asset does not exist at ${path.relative(process.cwd(), assetPath)}.`,
+      });
+    }
+  }
+
+  return {
+    valid: issues.length === 0,
+    issues,
+  };
+}
+
+export function assertValidBlogVisualAssets(
+  markdown: string,
+  options: BlogVisualAssetValidationOptions
+): void {
+  const result = validateBlogVisualAssets(markdown, options);
+
+  if (!result.valid) {
+    const details = result.issues
+      .map(issue => `${issue.src}: ${issue.reason}`)
+      .join("; ");
+    throw new Error(`Invalid blog visual asset reference(s): ${details}`);
+  }
+}

--- a/tests/blogVisualAssets.test.mjs
+++ b/tests/blogVisualAssets.test.mjs
@@ -1,0 +1,166 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  assertValidBlogVisualAssets,
+  extractBlogImageReferences,
+  extractBlogImageSources,
+  isInlineImageDataUri,
+  validateBlogVisualAssets,
+} from "../src/utils/blogVisualAssets.ts";
+
+function createPublicDirWithAsset(postSlug = "durable-post") {
+  const publicDir = fs.mkdtempSync(path.join(os.tmpdir(), "bd-blog-assets-"));
+  const assetDir = path.join(publicDir, "assets", "blog", postSlug);
+  fs.mkdirSync(assetDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(assetDir, "pipeline.svg"),
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>'
+  );
+  return publicDir;
+}
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(error);
+  }
+}
+
+test("extracts Markdown and HTML image references with alt and caption metadata", () => {
+  const markdown = [
+    '![Pipeline diagram](/assets/blog/durable-post/pipeline.svg "Build gate diagram")',
+    '<img src="/assets/blog/durable-post/pipeline.svg" alt="Pipeline diagram" title="Build gate diagram" />',
+  ].join("\n");
+
+  assert.deepEqual(extractBlogImageSources(markdown), [
+    "/assets/blog/durable-post/pipeline.svg",
+  ]);
+  assert.deepEqual(extractBlogImageReferences(markdown), [
+    {
+      src: "/assets/blog/durable-post/pipeline.svg",
+      altText: "Pipeline diagram",
+      caption: "Build gate diagram",
+      source: "markdown",
+    },
+    {
+      src: "/assets/blog/durable-post/pipeline.svg",
+      altText: "Pipeline diagram",
+      caption: "Build gate diagram",
+      source: "html",
+    },
+  ]);
+});
+
+test("accepts durable blog visual assets stored under public/assets/blog/<post-slug>", () => {
+  const publicDir = createPublicDirWithAsset();
+  const markdown =
+    '![Pipeline diagram](/assets/blog/durable-post/pipeline.svg "Build gate diagram")';
+
+  const result = validateBlogVisualAssets(markdown, {
+    postSlug: "durable-post",
+    publicDir,
+  });
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.issues, []);
+  assert.doesNotThrow(() =>
+    assertValidBlogVisualAssets(markdown, {
+      postSlug: "durable-post",
+      publicDir,
+    })
+  );
+});
+
+test("ignores external image URLs so existing posts remain unaffected", () => {
+  const result = validateBlogVisualAssets(
+    "![Remote source](https://images.example.test/photo.jpg)",
+    {
+      postSlug: "durable-post",
+      publicDir: createPublicDirWithAsset(),
+    }
+  );
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.issues, []);
+});
+
+test("rejects inline data image URIs", () => {
+  const markdown = "![Inline SVG](data:image/svg+xml;base64,PHN2Zy8+)";
+  const result = validateBlogVisualAssets(markdown, {
+    postSlug: "durable-post",
+    publicDir: createPublicDirWithAsset(),
+  });
+
+  assert.equal(isInlineImageDataUri("data:image/png;base64,AAAA"), true);
+  assert.equal(result.valid, false);
+  assert.match(result.issues[0].reason, /Inline data:image URIs are not allowed/);
+  assert.throws(
+    () =>
+      assertValidBlogVisualAssets(markdown, {
+        postSlug: "durable-post",
+        publicDir: createPublicDirWithAsset(),
+      }),
+    /Invalid blog visual asset reference/
+  );
+});
+
+test("rejects assets outside the current post asset directory", () => {
+  const result = validateBlogVisualAssets(
+    '![Other post diagram](/assets/blog/other-post/pipeline.svg "Other caption")',
+    {
+      postSlug: "durable-post",
+      publicDir: createPublicDirWithAsset(),
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(
+    result.issues[0].reason,
+    /must live under \/assets\/blog\/durable-post\//
+  );
+});
+
+test("rejects missing assets and missing alt or caption metadata", () => {
+  const result = validateBlogVisualAssets(
+    "![](/assets/blog/durable-post/missing.svg)",
+    {
+      postSlug: "durable-post",
+      publicDir: createPublicDirWithAsset(),
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.equal(result.issues.length, 3);
+  assert.match(result.issues[0].reason, /non-empty alt text/);
+  assert.match(result.issues[1].reason, /caption\/title/);
+  assert.match(result.issues[2].reason, /does not exist/);
+});
+
+test("rejects parent-directory path traversal segments", () => {
+  const result = validateBlogVisualAssets(
+    '![Unsafe](/assets/blog/durable-post/../other.svg "Unsafe caption")',
+    {
+      postSlug: "durable-post",
+      publicDir: createPublicDirWithAsset(),
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.match(result.issues[0].reason, /parent-directory segments/);
+});
+
+console.log(`PASS ${passed} FAIL ${failed}`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary

Implements a durable repo-backed visual asset pipeline for blog posts so future diagrams can live as normal static assets instead of oversized Markdown data URIs.

Closes #20.

## Why this matters

The A2A post proved that data-URI SVGs work as an emergency rendering workaround, but they are hard to diff, hard to review, and too brittle as the default publishing standard. This PR moves the standard toward durable, auditable blog visuals.

## Changes

Source / validation:
- Adds `src/utils/blogVisualAssets.ts` to validate local blog visual references.
- Rejects inline `data:image` URIs in post content.
- Requires repo-backed blog visuals to use `/assets/blog/<post-slug>/...` paths backed by `public/assets/blog/<post-slug>/...`.
- Requires local visuals to have useful alt text plus title/caption context.
- Wires validation into the live filesystem loader and POST/PATCH post API paths.
- Adds `tests/blogVisualAssets.test.mjs` and `pnpm test`.

Docs / operating context:
- Updates README, API.md, CLAUDE.md, and `.otoxan` guidance with the durable asset convention and validation command.

## Path boundary

app/source-code-touching + docs

## Validation

- `pnpm test` — PASS 7 FAIL 0
- `pnpm run lint` — PASS
- `pnpm run format:check` — PASS
- `pnpm run build` — PASS

## Notes

No production publish/unpublish action is included. No generated stock/AI image pipeline is added.