### PR TITLE
feat(ai-discovery): add search visibility verification harness (Phase 5)

### DIFF
--- a/LLM_CRAWL_MANIFEST.md
+++ b/LLM_CRAWL_MANIFEST.md
@@ -134,11 +134,38 @@ curl -si https://berryhill.dev/llms.txt | head -5
 2. Submit sitemap to Google Search Console
 3. Submit sitemap to Bing Webmaster Tools
 
+### ✅ Phase 5 (2026-06-25, PR pending):
+1. ✅ Added `scripts/checkSearchVisibility.mjs` verification harness
+2. ✅ Added `pnpm run check:search-visibility` package script
+3. ✅ Documented Pagefind SSR limitation
+4. ✅ Updated `LLM_CRAWL_MANIFEST.md` with verification section
+
 ### 📋 Planned:
 1. Add FAQPage schema if FAQ content is created
 2. Monitor crawler activity in server logs
 3. Submit sitemap to Google Search Console
 4. Submit sitemap to Bing Webmaster Tools
+
+## Verification Script
+
+A repeatable verification harness verifies all crawl surfaces in one command:
+
+```bash
+pnpm run check:search-visibility
+# Optional: point at a different base URL
+pnpm run check:search-visibility -- https://staging.berryhill.dev
+```
+
+Checks performed:
+| Check | Path | Assertion |
+|-------|------|-----------|
+| robots.txt | /robots.txt | Sitemap: directive or allow/disallow rules |
+| sitemap-index | /sitemap-index.xml | sitemap XML structure |
+| rss.xml | /rss.xml | RSS 2.0 channel element |
+| llms.txt | /llms.txt | title + sitemap + RSS references (requires PR #35 deployed) |
+| post JSON-LD | /posts/{slug}/ | JSON-LD structured data (optional) |
+
+Pagefind note: requires static-site build output (`public/pagefind/`). With SSR/standalone-node mode, Pagefind indexing runs post-build in CI. Verify with `curl -s https://berryhill.dev/search | grep pagefind`.
 
 ## Notes
 - As of 2025, GPTBot accounts for ~30% of AI crawler traffic
@@ -171,4 +198,4 @@ curl -si https://berryhill.dev/llms.txt | head -5
 - ✅ Created LLM Crawl Manifest documentation
 
 ## Last Updated
-2025-10-29
+2026-06-25

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "astro build",
     "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
+    "check:search-visibility": "node scripts/checkSearchVisibility.mjs",
     "preview": "astro preview",
     "sync": "astro sync",
     "astro": "astro",

--- a/scripts/checkSearchVisibility.mjs
+++ b/scripts/checkSearchVisibility.mjs
@@ -1,0 +1,159 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+/**
+ * scripts/checkSearchVisibility.mjs
+ *
+ * Verifies crawler/AI-agent discoverability surfaces for berryhill.dev:
+ *   - robots.txt       (sitemap reference, AI-crawler directives)
+ *   - sitemap.xml      (index)
+ *   - rss.xml          (feed)
+ *   - llms.txt         (LLM manifest, requires PR #35 deployed)
+ *   - representative post JSON-LD schema
+ *
+ * Usage:
+ *   pnpm run check:search-visibility
+ *   pnpm run check:search-visibility -- https://berryhill.dev
+ *
+ * Exit codes:
+ *   0  - all checks pass
+ *   1  - one or more checks fail
+ *   2  - unexpected error (network, etc.)
+ */
+
+// Uses native fetch (Node 18+); no external dependency required.
+
+const BASE = process.argv.find((a) => /^https?:\/\//i.test(a)) ?? "https://berryhill.dev";
+
+const CHECKS = [
+  {
+    name: "robots.txt",
+    path: "/robots.txt",
+    status: 200,
+    assert(text) {
+      return (
+        text.includes("Sitemap:") ||
+        text.includes("sitemap") ||
+        text.includes("Allow:") ||
+        text.includes("Disallow:")
+      );
+    },
+    assertLabel: "Sitemap: directive or allow/disallow rules present",
+  },
+  {
+    name: "sitemap-index",
+    path: "/sitemap-index.xml",
+    status: 200,
+    assert(text) {
+      return text.includes("sitemap");
+    },
+    assertLabel: "sitemap XML structure present",
+  },
+  {
+    name: "rss.xml",
+    path: "/rss.xml",
+    status: 200,
+    assert(text) {
+      return text.includes("<rss") || text.includes("<channel>");
+    },
+    assertLabel: "RSS 2.0 structure present",
+  },
+  {
+    name: "llms.txt",
+    path: "/llms.txt",
+    status: 200,
+    contentType: "text/plain",
+    assert(text) {
+      return (
+        text.includes("#") &&
+        (text.includes("Sitemap") || text.includes("sitemap")) &&
+        (text.includes("RSS") || text.includes("rss"))
+      );
+    },
+    assertLabel: "llms.txt manifest with title + sitemap + RSS references",
+  },
+  {
+    name: "post JSON-LD schema",
+    path: "/posts/quantum-is-coming-agent-workflows-should-start-leaving-breadcrumbs/",
+    status: 200,
+    assert(text) {
+      return text.includes('application/ld+json') || text.includes('"@type"');
+    },
+    assertLabel: "JSON-LD structured data present",
+    optional: true,
+  },
+];
+
+const PAGEFIND_NOTE =
+  "NOTE: Pagefind requires a static-site build output (public/pagefind/). " +
+  "With SSR/standalone-node mode, Pagefind indexing runs post-build in CI. " +
+  "Verify: curl -s https://berryhill.dev/search | grep pagefind";
+
+async function run() {
+  let passed = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  console.log(`Checking search visibility surfaces at: ${BASE}\n`);
+
+  for (const check of CHECKS) {
+    const url = new URL(check.path, BASE).href;
+    let ok = false;
+    let reason = "";
+
+    try {
+      const res = await fetch(url, {
+        redirect: "follow",
+        headers: { "User-Agent": "berryhill-dev-visibility-check/1.0" },
+      });
+
+      if (res.status !== check.status) {
+        reason = `HTTP ${res.status} (expected ${check.status})`;
+      } else {
+        const text = await res.text();
+
+        if (check.contentType) {
+          const ct = res.headers.get("content-type") ?? "";
+          if (!ct.includes(check.contentType.replace(/;.*/, ""))) {
+            reason = `Content-Type ${ct} does not match ${check.contentType}`;
+          }
+        }
+
+        if (!reason && !check.assert(text)) {
+          reason = `Assertion failed: ${check.assertLabel}`;
+        }
+
+        if (!reason) {
+          ok = true;
+        }
+      }
+    } catch (err) {
+      reason = err instanceof Error ? err.message : String(err);
+    }
+
+    if (ok) {
+      passed++;
+      console.log(`  PASS  ${check.name.padEnd(25)} ${check.path}`);
+    } else if (check.optional) {
+      skipped++;
+      console.log(`  WARN  ${check.name.padEnd(25)} ${check.path}  (optional: ${reason})`);
+    } else {
+      failed++;
+      console.error(`  FAIL  ${check.name.padEnd(25)} ${check.path}  ${reason}`);
+    }
+  }
+
+  console.log(`\n${PAGEFIND_NOTE}\n`);
+  console.log(`Results: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  } else if (passed === 0) {
+    console.error("No checks passed — network or base URL issue?");
+    process.exitCode = 2;
+  }
+}
+
+run().catch((err) => {
+  console.error("Unexpected error:", err instanceof Error ? err.message : err);
+  process.exitCode = 2;
+});


### PR DESCRIPTION
## Summary

Add a repeatable verification script for AI/LLM crawler discoverability surfaces per [Issue #33](https://github.com/berryhill/bd-site/issues/33).

## Changes

### scripts/checkSearchVisibility.mjs (new)

Checks the following surfaces against a configurable base URL (default: `https://berryhill.dev`):

| Check | Path | Assertion |
|-------|------|-----------|
| robots.txt | /robots.txt | Sitemap: directive or allow/disallow rules |
| sitemap-index | /sitemap-index.xml | sitemap XML structure |
| rss.xml | /rss.xml | RSS 2.0 channel element |
| llms.txt | /llms.txt | title + sitemap + RSS refs (requires PR #35 deployed) |
| post JSON-LD | /posts/{slug}/ | JSON-LD structured data (optional) |

Exit codes: `0` all pass, `1` one or more failed, `2` unexpected error.

Uses native Node 18+ `fetch` — no external dependency required.

### package.json

Adds `check:search-visibility` script pointing to the new script.

### LLM_CRAWL_MANIFEST.md

Documents the verification command, the check table, and the Pagefind SSR limitation. Marks Phase 5 as complete.

## Verification

```
pnpm run lint           # passes
pnpm run format:check   # passes
pnpm run build          # passes

pnpm run check:search-visibility
pnpm run check:search-visibility -- https://staging.berryhill.dev
```

Post-deploy verification (after PRs #29 and #35 are live):

```
curl -si https://berryhill.dev/llms.txt | head -3
pnpm run check:search-visibility -- https://berryhill.dev
```

## Acceptance criteria (from issue)

- [x] `pnpm run check:search-visibility` package script added
- [x] Script verifies robots.txt, sitemap, rss, llms.txt
- [x] Script fails loudly on missing surfaces
- [x] `pnpm run format:check` passes
- [x] `pnpm run build` passes
- [x] LLM_CRAWL_MANIFEST.md updated

## Path boundary

app/tooling-touching

Closes berryhill/bd-site#33
