### PR TITLE
fix(deploy): bump helm image tag to deploy /llms.txt

### DIFF
--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   repository: ghcr.io/berryhill/bd-site
-  tag: 0.0.42
+  tag: 0.0.43
   pullPolicy: IfNotPresent
 
 service:


### PR DESCRIPTION
## Summary
Bump Helm image tag from `0.0.42` to `0.0.43` to trigger deployment that includes the `/llms.txt` implementation from PRs #35-#37.

## Problem
The `/llms.txt` endpoint was implemented and merged, but the Helm chart was not re-deployed. Production returns 404:
```
curl -si https://berryhill.dev/llms.txt
HTTP/2 404
```

## Solution
Update `helm/values.yaml` `image.tag` to `0.0.43` to pick up the latest Docker build that includes `src/pages/llms.txt.ts`.

## Path boundary
deployment-touching

## Related
- Closes #39
- Related: PRs #35, #36, #37 (llms.txt implementation)