### PR TITLE
feat: add Atom/feed aliases and feed autodiscovery

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -132,13 +132,19 @@ const structuredData = {
       set:html={JSON.stringify(structuredData)}
     />
 
-    <!-- Enable RSS feed auto-discovery  -->
+    <!-- Enable RSS and Atom feed auto-discovery -->
     <!-- https://docs.astro.build/en/recipes/rss/#enabling-rss-feed-auto-discovery -->
     <link
       rel="alternate"
       type="application/rss+xml"
-      title={SITE.title}
+      title={`${SITE.title} RSS`}
       href={new URL("rss.xml", Astro.site)}
+    />
+    <link
+      rel="alternate"
+      type="application/atom+xml"
+      title={`${SITE.title} Atom`}
+      href={new URL("atom.xml", Astro.site)}
     />
 
     <meta name="theme-color" content="" />

--- a/src/pages/atom.xml.ts
+++ b/src/pages/atom.xml.ts
@@ -1,0 +1,74 @@
+import { getLiveCollection } from "astro:content";
+import { SITE } from "@/config";
+import { getPath } from "@/utils/getPath";
+import getSortedPosts from "@/utils/getSortedPosts";
+
+export const prerender = false;
+
+export async function GET() {
+  const { entries: posts } = await getLiveCollection("liveBlog");
+  const sortedPosts = getSortedPosts(posts || []);
+
+  const website = SITE.website.endsWith("/")
+    ? SITE.website
+    : `${SITE.website}/`;
+
+  const now = new Date().toUTCString();
+  const feedUrl = `${website}atom.xml`;
+
+  const entries = await Promise.all(
+    sortedPosts.map(async ({ data, id, filePath }) => {
+      const postUrl = getPath(id, filePath);
+      const fullUrl = new URL(postUrl, website).href;
+      const pubDate = new Date(data.modDatetime ?? data.pubDatetime);
+
+      const summary = data.description ?? "";
+
+      const tags = (data.tags ?? [])
+        .map(tag => `      <category term="${escapeXml(String(tag))}" />`)
+        .join("\n");
+
+      return `    <entry>
+      <title>${escapeXml(data.title ?? "")}</title>
+      <id>${escapeXml(fullUrl)}</id>
+      <updated>${pubDate.toISOString()}</updated>
+      <published>${pubDate.toISOString()}</published>
+      <summary type="text">${escapeXml(summary)}</summary>
+      <link href="${escapeXml(fullUrl)}" rel="alternate" type="text/html" />
+${tags}
+    </entry>`;
+    })
+  );
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <id>${escapeXml(website)}</id>
+  <title>${escapeXml(SITE.title)}</title>
+  <subtitle>${escapeXml(SITE.desc ?? "")}</subtitle>
+  <updated>${now}</updated>
+  <author>
+    <name>${escapeXml(SITE.author ?? "")}</name>
+  </author>
+  <link href="${escapeXml(feedUrl)}" rel="self" type="application/atom+xml" />
+  <link href="${escapeXml(website)}" rel="alternate" type="text/html" />
+  <generator>Astro v5.x</generator>
+  <rights>Copyright ${new Date().getFullYear()} ${escapeXml(SITE.author ?? "")}</rights>
+${entries.join("\n")}
+</feed>`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/atom+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=3600",
+    },
+  });
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/src/pages/feed.xml.ts
+++ b/src/pages/feed.xml.ts
@@ -1,0 +1,5 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const GET: APIRoute = ({ redirect }) => redirect("/rss.xml", 301);


### PR DESCRIPTION
## Summary

Adds `/atom.xml` (valid Atom 1.0 feed) and `/feed.xml` (301 redirect to `/rss.xml`), and updates the site layout to advertise both RSS and Atom via `<link rel="alternate">` autodiscovery tags.

## Changes

- **src/pages/atom.xml.ts** (new) - Generates an Atom 1.0 feed using the same post data as the RSS feed, with proper `<entry>` elements, `<id>`, `<updated>`, `<published>`, `<summary>`, `<link>`, and `<category>` tags.
- **src/pages/feed.xml.ts** (new) - 301 redirect to `/rss.xml` as specified in the issue implementation sketch.
- **src/layouts/Layout.astro** (modified) - Adds `<link rel="alternate" type="application/atom+xml">` autodiscovery tag alongside the existing RSS tag. RSS title updated to "{SITE.title} RSS" for clarity.

## Path boundary

app/source-code-touching

## Verification

```
pnpm run build  # passes
```

Post-merge commands (from issue):

```bash
curl -i https://berryhill.dev/atom.xml
curl -i https://berryhill.dev/feed.xml
curl -s https://berryhill.dev/ | grep -E "rss.xml|atom.xml"
```

## Closes

Closes #30
