### PR TITLE
feat: page-specific structured data (issue #31)

### DIFF
--- a/LLM_CRAWL_MANIFEST.md
+++ b/LLM_CRAWL_MANIFEST.md
@@ -77,18 +77,38 @@ Previously, only 6 static pages were included. Now ALL published blog posts are 
 
 ## Structured Data
 
-### Current Implementation:
-- **BlogPosting**: ✅ Implemented on all post pages
-  - headline
-  - image
-  - datePublished
-  - dateModified
-  - author (Person schema)
+### Current Implementation (Phase 3 — PR #43):
+All structured data uses [Schema.org](https://schema.org) JSON-LD. The global `BlogPosting` baseline has been replaced with page-specific schema types. Values are stripped of `undefined`/`null` at build time.
+
+#### Page-specific schemas
+
+| Page | Schema Type | Key Fields |
+|---|---|---|
+| Homepage | `WebSite` | name, url, description, image, author (Person) |
+| About | `Person` | name, url, image, description |
+| Posts list, Tags, Archives | `CollectionPage` | name, description, url, isPartOf (WebSite) |
+| Post detail | `BlogPosting` | headline, description, url, mainEntityOfPage (WebPage), image, keywords (tags), datePublished, dateModified, author (Person array), publisher (Person) |
+
+#### BlogPosting enriched fields (post detail pages)
+- `headline` — post title
+- `description` — post description frontmatter field
+- `url` — canonical post URL
+- `mainEntityOfPage` — WebPage referencing the post URL
+- `image` — OG image URL (if present)
+- `keywords` — post tags as array
+- `datePublished` — ISO 8601 publication datetime
+- `dateModified` — ISO 8601 last-modified datetime (omitted if absent)
+- `author` — Person array with name and profile URL
+- `publisher` — Person with name and profile URL
+
+#### Implementation notes
+- Utility: `src/utils/structuredData.ts` — typed builders for each schema type
+- Layout wiring: `Layout.astro` accepts optional `jsonLd` prop, renders only when provided
+- Tests: `tests/structuredData.test.mjs` — validates schema types, required fields, and absence of undefined values
 
 ### Planned Additions:
 - FAQPage schema (if FAQ content is added)
 - Product schema (if relevant)
-- Article schema (enhanced version of BlogPosting)
 
 ## Content Features
 - **RSS Feed**: https://berryhill.dev/rss.xml ✅ **FULLY OPTIMIZED**

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",
     "preview": "astro preview",

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -4,6 +4,7 @@ import Footer from "@/components/Footer.astro";
 import Breadcrumb from "@/components/Breadcrumb.astro";
 import Layout from "./Layout.astro";
 import { SITE } from "@/config";
+import { buildPersonJsonLd } from "@/utils/structuredData";
 
 export interface Props {
   frontmatter: {
@@ -13,9 +14,15 @@ export interface Props {
 }
 
 const { frontmatter } = Astro.props;
+const jsonLd = buildPersonJsonLd({
+  name: SITE.author,
+  url: SITE.profile,
+  image: new URL("/matt_headshot.jpeg", SITE.website).href,
+  description: frontmatter.description ?? SITE.desc,
+});
 ---
 
-<Layout title={`${frontmatter.title} | ${SITE.title}`}>
+<Layout title={`${frontmatter.title} | ${SITE.title}`} jsonLd={jsonLd}>
   <Header />
   <Breadcrumb />
   <main id="main-content">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -13,25 +13,27 @@ export interface Props {
   profile?: string;
   description?: string;
   ogImage?: string;
-  canonicalURL?: string;
+  canonicalURL?: string | URL;
   pubDatetime?: Date;
   modDatetime?: Date | null;
   scrollSmooth?: boolean;
+  jsonLd?: object | object[];
 }
 
 const {
   title = SITE.title,
   author = SITE.author,
-  profile = SITE.profile,
   description = SITE.desc,
   ogImage = SITE.ogImage ? `/${SITE.ogImage}` : "/og.png",
   canonicalURL = new URL(Astro.url.pathname, Astro.url),
   pubDatetime,
   modDatetime,
   scrollSmooth = false,
+  jsonLd,
 } = Astro.props;
 
 const socialImageURL = new URL(ogImage, Astro.url);
+const jsonLdItems = jsonLd ? (Array.isArray(jsonLd) ? jsonLd : [jsonLd]) : [];
 
 const gaInitScript = `
 window.dataLayer = window.dataLayer || [];
@@ -53,22 +55,6 @@ document.addEventListener("astro:page-load", () => {
   }
 });
 `;
-
-const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "BlogPosting",
-  headline: `${title}`,
-  image: `${socialImageURL}`,
-  datePublished: `${pubDatetime?.toISOString()}`,
-  ...(modDatetime && { dateModified: modDatetime.toISOString() }),
-  author: [
-    {
-      "@type": "Person",
-      name: `${author}`,
-      ...(profile && { url: profile }),
-    },
-  ],
-};
 ---
 
 <!doctype html>
@@ -126,11 +112,15 @@ const structuredData = {
     <meta property="twitter:image" content={socialImageURL} />
 
     <!-- Google JSON-LD Structured data -->
-    <script
-      type="application/ld+json"
-      is:inline
-      set:html={JSON.stringify(structuredData)}
-    />
+    {
+      jsonLdItems.map(item => (
+        <script
+          type="application/ld+json"
+          is:inline
+          set:html={JSON.stringify(item)}
+        />
+      ))
+    }
 
     <!-- Enable RSS and Atom feed auto-discovery -->
     <!-- https://docs.astro.build/en/recipes/rss/#enabling-rss-feed-auto-discovery -->

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -15,6 +15,7 @@ import { slugifyStr } from "@/utils/slugify";
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
 import { SITE } from "@/config";
+import { buildBlogPostingJsonLd } from "@/utils/structuredData";
 
 export interface Props {
   post: CollectionEntry<"liveBlog">;
@@ -58,6 +59,22 @@ const ogImage = ogImageUrl
   ? new URL(ogImageUrl, Astro.url.origin).href
   : undefined;
 
+const postUrl = canonicalURL
+  ? new URL(canonicalURL, Astro.url.origin).href
+  : new URL(getPath(post.id, post.filePath), Astro.url.origin).href;
+
+const jsonLd = buildBlogPostingJsonLd({
+  title,
+  description,
+  url: postUrl,
+  image: ogImage,
+  author: author ?? SITE.author,
+  authorUrl: SITE.profile,
+  pubDatetime,
+  modDatetime,
+  tags,
+});
+
 const layoutProps = {
   title: `${title} | ${SITE.title}`,
   author,
@@ -67,6 +84,7 @@ const layoutProps = {
   canonicalURL: canonicalURL ?? undefined,
   ogImage,
   scrollSmooth: true,
+  jsonLd,
 };
 
 /* ========== Prev/Next Posts ========== */

--- a/src/pages/archives/index.astro
+++ b/src/pages/archives/index.astro
@@ -9,6 +9,7 @@ import Footer from "@/components/Footer.astro";
 import Card from "@/components/Card.astro";
 import getPostsByGroupCondition from "@/utils/getPostsByGroupCondition";
 import { SITE } from "@/config";
+import { buildCollectionPageJsonLd } from "@/utils/structuredData";
 
 // Redirect to 404 page if `showArchives` config is false
 if (!SITE.showArchives) {
@@ -32,9 +33,15 @@ const months = [
   "November",
   "December",
 ];
+const jsonLd = buildCollectionPageJsonLd({
+  title: `Archives | ${SITE.title}`,
+  description: "All the articles I've archived.",
+  url: new URL(Astro.url.pathname, Astro.url.origin).href,
+  isPartOf: SITE.title,
+});
 ---
 
-<Layout title={`Archives | ${SITE.title}`}>
+<Layout title={`Archives | ${SITE.title}`} jsonLd={jsonLd}>
   <Header />
   <Main pageTitle="Archives" pageDesc="All the articles I've archived.">
     {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -15,15 +15,25 @@ import IconRss from "@/assets/icons/IconRss.svg";
 import IconArrowRight from "@/assets/icons/IconArrowRight.svg";
 import { SITE } from "@/config";
 import { SOCIALS } from "@/constants";
+import { buildWebSiteJsonLd } from "@/utils/structuredData";
 
 const { entries: posts } = await getLiveCollection("liveBlog");
 
 const sortedPosts = getSortedPosts(posts || []);
 const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
 const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
+const jsonLd = buildWebSiteJsonLd({
+  name: SITE.title,
+  url: SITE.website,
+  description: SITE.desc,
+  image: new URL(SITE.ogImage ? `/${SITE.ogImage}` : "/og.png", SITE.website)
+    .href,
+  author: SITE.author,
+  authorUrl: SITE.profile,
+});
 ---
 
-<Layout>
+<Layout jsonLd={jsonLd}>
   <Header />
   <main
     id="main-content"

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -10,6 +10,7 @@ import Card from "@/components/Card.astro";
 import Pagination from "@/components/Pagination.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
 import { SITE } from "@/config";
+import { buildCollectionPageJsonLd } from "@/utils/structuredData";
 
 const { page: pageParam } = Astro.params;
 
@@ -48,9 +49,15 @@ const page = {
       currentPage < totalPages ? `/posts/page/${currentPage + 1}` : undefined,
   },
 };
+const jsonLd = buildCollectionPageJsonLd({
+  title: `Posts | ${SITE.title}`,
+  description: "All the articles I've posted.",
+  url: new URL(Astro.url.pathname, Astro.url.origin).href,
+  isPartOf: SITE.title,
+});
 ---
 
-<Layout title={`Posts | ${SITE.title}`}>
+<Layout title={`Posts | ${SITE.title}`} jsonLd={jsonLd}>
   <Header />
   <Main pageTitle="Posts" pageDesc="All the articles I've posted.">
     <ul class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">

--- a/src/pages/tags/[tag]/[...page].astro
+++ b/src/pages/tags/[tag]/[...page].astro
@@ -11,6 +11,7 @@ import Pagination from "@/components/Pagination.astro";
 import getUniqueTags from "@/utils/getUniqueTags";
 import getPostsByTag from "@/utils/getPostsByTag";
 import { SITE } from "@/config";
+import { buildCollectionPageJsonLd } from "@/utils/structuredData";
 
 const { tag, page: pageParam } = Astro.params;
 const currentPage = pageParam ? parseInt(pageParam) : 1;
@@ -54,9 +55,15 @@ const page = {
       currentPage < totalPages ? `/tags/${tag}/${currentPage + 1}` : undefined,
   },
 };
+const jsonLd = buildCollectionPageJsonLd({
+  title: `Tag: ${tagName} | ${SITE.title}`,
+  description: `All the articles with the tag "${tagName}".`,
+  url: new URL(Astro.url.pathname, Astro.url.origin).href,
+  isPartOf: SITE.title,
+});
 ---
 
-<Layout title={`Tag: ${tagName} | ${SITE.title}`}>
+<Layout title={`Tag: ${tagName} | ${SITE.title}`} jsonLd={jsonLd}>
   <Header />
   <Main
     pageTitle={[`Tag:`, `${tagName}`]}

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -9,13 +9,20 @@ import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import getUniqueTags from "@/utils/getUniqueTags";
 import { SITE } from "@/config";
+import { buildCollectionPageJsonLd } from "@/utils/structuredData";
 
 const { entries: posts } = await getLiveCollection("liveBlog");
 
 const tags = getUniqueTags(posts || []);
+const jsonLd = buildCollectionPageJsonLd({
+  title: `Tags | ${SITE.title}`,
+  description: "All the tags used in posts.",
+  url: new URL(Astro.url.pathname, Astro.url.origin).href,
+  isPartOf: SITE.title,
+});
 ---
 
-<Layout title={`Tags | ${SITE.title}`}>
+<Layout title={`Tags | ${SITE.title}`} jsonLd={jsonLd}>
   <Header />
   <Main pageTitle="Tags" pageDesc="All the tags used in posts.">
     <ul class="flex flex-wrap gap-2">

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,132 @@
+type JsonLdScalar = string | number | boolean;
+type JsonLdValue =
+  | JsonLdScalar
+  | JsonLdObject
+  | JsonLdValue[]
+  | null
+  | undefined;
+type JsonLdObject = { [key: string]: JsonLdValue };
+
+export interface BlogPostingJsonLdInput {
+  title: string;
+  description: string;
+  url: string;
+  image?: string;
+  author: string;
+  authorUrl?: string;
+  pubDatetime: Date;
+  modDatetime?: Date | null;
+  tags?: string[];
+}
+
+export interface WebSiteJsonLdInput {
+  name: string;
+  url: string;
+  description: string;
+  image?: string;
+  author: string;
+  authorUrl?: string;
+}
+
+export interface PersonJsonLdInput {
+  name: string;
+  url?: string;
+  image?: string;
+  description?: string;
+}
+
+export interface CollectionPageJsonLdInput {
+  title: string;
+  description: string;
+  url: string;
+  isPartOf?: string;
+}
+
+function stripNullishValues<T extends JsonLdValue>(value: T): T {
+  if (Array.isArray(value)) {
+    return value
+      .filter(item => item !== undefined && item !== null)
+      .map(item => stripNullishValues(item)) as T;
+  }
+
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value)
+        .filter(
+          ([, entryValue]) => entryValue !== undefined && entryValue !== null
+        )
+        .map(([key, entryValue]) => [key, stripNullishValues(entryValue)])
+    ) as T;
+  }
+
+  return value;
+}
+
+function buildPersonReference(name: string, url?: string) {
+  return stripNullishValues({
+    "@type": "Person",
+    name,
+    url,
+  });
+}
+
+export function buildBlogPostingJsonLd(input: BlogPostingJsonLdInput) {
+  const author = buildPersonReference(input.author, input.authorUrl);
+
+  return stripNullishValues({
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: input.title,
+    description: input.description,
+    url: input.url,
+    mainEntityOfPage: {
+      "@type": "WebPage",
+      "@id": input.url,
+    },
+    image: input.image ? [input.image] : undefined,
+    keywords: input.tags?.length ? input.tags : undefined,
+    datePublished: input.pubDatetime.toISOString(),
+    dateModified: input.modDatetime?.toISOString(),
+    author: [author],
+    publisher: author,
+  });
+}
+
+export function buildWebSiteJsonLd(input: WebSiteJsonLdInput) {
+  return stripNullishValues({
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: input.name,
+    url: input.url,
+    description: input.description,
+    image: input.image ? [input.image] : undefined,
+    author: buildPersonReference(input.author, input.authorUrl),
+  });
+}
+
+export function buildPersonJsonLd(input: PersonJsonLdInput) {
+  return stripNullishValues({
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: input.name,
+    url: input.url,
+    image: input.image,
+    description: input.description,
+  });
+}
+
+export function buildCollectionPageJsonLd(input: CollectionPageJsonLdInput) {
+  return stripNullishValues({
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    name: input.title,
+    description: input.description,
+    url: input.url,
+    isPartOf: input.isPartOf
+      ? {
+          "@type": "WebSite",
+          name: input.isPartOf,
+        }
+      : undefined,
+  });
+}

--- a/tests/structuredData.test.mjs
+++ b/tests/structuredData.test.mjs
@@ -1,0 +1,158 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import {
+  buildBlogPostingJsonLd,
+  buildCollectionPageJsonLd,
+  buildPersonJsonLd,
+  buildWebSiteJsonLd,
+} from "../src/utils/structuredData.ts";
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(error);
+  }
+}
+
+function containsUndefined(value) {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (Array.isArray(value)) {
+    return value.some(containsUndefined);
+  }
+
+  if (value && typeof value === "object") {
+    return Object.values(value).some(containsUndefined);
+  }
+
+  return false;
+}
+
+test("BlogPosting includes enriched post schema fields", () => {
+  const jsonLd = buildBlogPostingJsonLd({
+    title: "Agentic Workflows",
+    description: "A practical note on agentic workflows.",
+    url: "https://berryhill.dev/posts/agentic-workflows/",
+    image: "https://berryhill.dev/posts/agentic-workflows/index.png",
+    author: "Berryhill",
+    authorUrl: "https://berryhill.dev/",
+    pubDatetime: new Date("2026-01-02T03:04:05.000Z"),
+    modDatetime: new Date("2026-01-03T04:05:06.000Z"),
+    tags: ["AI", "Agentic Development"],
+  });
+
+  assert.equal(jsonLd["@type"], "BlogPosting");
+  assert.equal(jsonLd.headline, "Agentic Workflows");
+  assert.equal(jsonLd.description, "A practical note on agentic workflows.");
+  assert.equal(jsonLd.url, "https://berryhill.dev/posts/agentic-workflows/");
+  assert.deepEqual(jsonLd.mainEntityOfPage, {
+    "@type": "WebPage",
+    "@id": "https://berryhill.dev/posts/agentic-workflows/",
+  });
+  assert.deepEqual(jsonLd.image, [
+    "https://berryhill.dev/posts/agentic-workflows/index.png",
+  ]);
+  assert.equal(jsonLd.datePublished, "2026-01-02T03:04:05.000Z");
+  assert.equal(jsonLd.dateModified, "2026-01-03T04:05:06.000Z");
+  assert.deepEqual(jsonLd.keywords, ["AI", "Agentic Development"]);
+  assert.deepEqual(jsonLd.author, [
+    {
+      "@type": "Person",
+      name: "Berryhill",
+      url: "https://berryhill.dev/",
+    },
+  ]);
+  assert.deepEqual(jsonLd.publisher, {
+    "@type": "Person",
+    name: "Berryhill",
+    url: "https://berryhill.dev/",
+  });
+});
+
+test("BlogPosting omits dateModified when absent and never contains undefined values", () => {
+  const withNullDate = buildBlogPostingJsonLd({
+    title: "Agentic Workflows",
+    description: "A practical note on agentic workflows.",
+    url: "https://berryhill.dev/posts/agentic-workflows/",
+    author: "Berryhill",
+    pubDatetime: new Date("2026-01-02T03:04:05.000Z"),
+    modDatetime: null,
+  });
+
+  const withUndefinedDate = buildBlogPostingJsonLd({
+    title: "Agentic Workflows",
+    description: "A practical note on agentic workflows.",
+    url: "https://berryhill.dev/posts/agentic-workflows/",
+    author: "Berryhill",
+    pubDatetime: new Date("2026-01-02T03:04:05.000Z"),
+  });
+
+  assert.equal("dateModified" in withNullDate, false);
+  assert.equal("dateModified" in withUndefinedDate, false);
+  assert.equal(containsUndefined(withNullDate), false);
+  assert.equal(containsUndefined(withUndefinedDate), false);
+});
+
+test("WebSite produces expected type and required fields", () => {
+  const jsonLd = buildWebSiteJsonLd({
+    name: "berryhill.dev",
+    url: "https://berryhill.dev/",
+    description: "Exploring agentic-first development.",
+    author: "Berryhill",
+    authorUrl: "https://berryhill.dev/",
+  });
+
+  assert.equal(jsonLd["@type"], "WebSite");
+  assert.equal(jsonLd.name, "berryhill.dev");
+  assert.equal(jsonLd.url, "https://berryhill.dev/");
+  assert.equal(jsonLd.description, "Exploring agentic-first development.");
+  assert.equal(jsonLd.author.name, "Berryhill");
+});
+
+test("Person produces expected type and required fields", () => {
+  const jsonLd = buildPersonJsonLd({
+    name: "Berryhill",
+    url: "https://berryhill.dev/",
+    image: "https://berryhill.dev/matt_headshot.jpeg",
+    description: "Agentic-first digital builder.",
+  });
+
+  assert.equal(jsonLd["@type"], "Person");
+  assert.equal(jsonLd.name, "Berryhill");
+  assert.equal(jsonLd.url, "https://berryhill.dev/");
+  assert.equal(jsonLd.image, "https://berryhill.dev/matt_headshot.jpeg");
+  assert.equal(jsonLd.description, "Agentic-first digital builder.");
+});
+
+test("CollectionPage produces expected type and required fields", () => {
+  const jsonLd = buildCollectionPageJsonLd({
+    title: "Posts | berryhill.dev",
+    description: "All the articles I've posted.",
+    url: "https://berryhill.dev/posts/page/2",
+    isPartOf: "berryhill.dev",
+  });
+
+  assert.equal(jsonLd["@type"], "CollectionPage");
+  assert.equal(jsonLd.name, "Posts | berryhill.dev");
+  assert.equal(jsonLd.description, "All the articles I've posted.");
+  assert.equal(jsonLd.url, "https://berryhill.dev/posts/page/2");
+  assert.deepEqual(jsonLd.isPartOf, {
+    "@type": "WebSite",
+    name: "berryhill.dev",
+  });
+});
+
+console.log(`PASS ${passed} FAIL ${failed}`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
**Path boundary:** app/source-code-touching

**What this does**
Replaces the global `BlogPosting` JSON-LD emitted by `Layout.astro` with page-specific schema.org structured data, as requested in #31.

**Changes**
- Adds `src/utils/structuredData.ts` with typed builders for:
  - `BlogPosting` (post detail pages)
  - `WebSite` (homepage)
  - `Person` (about page)
  - `CollectionPage` (posts list, tag index, tag filtered, archives)
- Updates `src/layouts/Layout.astro` to accept an optional `jsonLd` prop and render it only when provided.
- Updates `src/layouts/PostDetails.astro` to pass a rich `BlogPosting` block with `description`, `url`, `mainEntityOfPage`, `keywords`, `publisher`, `datePublished`, and `dateModified`.
- Updates homepage, posts list, tags, and archives pages to pass the appropriate schema.
- Updates `src/layouts/AboutLayout.astro` to pass a `Person` schema.
- Adds `tests/structuredData.test.mjs` and wires it into `package.json` `test`.

**Validation**
- `pnpm test` — PASS (7 + 5 + 5 tests)
- `pnpm run lint` — PASS
- `pnpm run build` — PASS
- `pnpm prettier --check <changed-files>` — PASS

**Notes**
- No visible article copy was changed.
- No new taxonomy was added; `keywords` uses existing post tags.
- The repository has pre-existing untracked content under `src/data/blog/` that was left untouched.

Closes #31
