### PR TITLE
feat: add related posts via shared-tag scoring (issue #32)

### DIFF
--- a/src/components/RelatedPosts.astro
+++ b/src/components/RelatedPosts.astro
@@ -1,0 +1,35 @@
+---
+import type { CollectionEntry } from "astro:content";
+import { getPath } from "@/utils/getPath";
+
+export interface Props {
+  posts: CollectionEntry<"liveBlog">[];
+}
+
+const { posts } = Astro.props;
+---
+
+{
+  posts.length > 0 && (
+    <aside class="related-posts" aria-labelledby="related-posts-heading">
+      <h2 id="related-posts-heading" class="mb-4 text-lg font-bold text-accent">
+        Related posts
+      </h2>
+      <ul class="space-y-3">
+        {posts.map(post => (
+          <li>
+            <a
+              href={getPath(post.id, post.filePath)}
+              class="group inline-flex items-center gap-2 transition-colors hover:text-accent"
+            >
+              <span class="text-accent opacity-0 transition-opacity group-hover:opacity-100">
+                →
+              </span>
+              <span>{post.data.title}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </aside>
+  )
+}

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -10,7 +10,9 @@ import EditPost from "@/components/EditPost.astro";
 import ShareLinks from "@/components/ShareLinks.astro";
 import BackButton from "@/components/BackButton.astro";
 import BackToTopButton from "@/components/BackToTopButton.astro";
+import RelatedPosts from "@/components/RelatedPosts.astro";
 import { getPath } from "@/utils/getPath";
+import { getRelatedPosts } from "@/utils/getRelatedPosts";
 import { slugifyStr } from "@/utils/slugify";
 import IconChevronLeft from "@/assets/icons/IconChevronLeft.svg";
 import IconChevronRight from "@/assets/icons/IconChevronRight.svg";
@@ -100,6 +102,8 @@ const currentPostIndex = allPosts.findIndex(a => a.id === post.id);
 const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
   currentPostIndex !== allPosts.length ? allPosts[currentPostIndex + 1] : null;
+
+const relatedPosts = getRelatedPosts(post, posts);
 ---
 
 <Layout {...layoutProps}>
@@ -148,6 +152,12 @@ const nextPost =
     <BackToTopButton />
 
     <ShareLinks />
+
+    <hr class="my-6 border-dashed" />
+
+    <div data-pagefind-ignore>
+      <RelatedPosts posts={relatedPosts} />
+    </div>
 
     <hr class="my-6 border-dashed" />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -236,3 +236,8 @@ html {
 :target {
   scroll-margin-block: 5ex;
 }
+
+.related-posts {
+  margin-block: 1.5rem;
+  padding-block: 0.5rem;
+}

--- a/src/utils/getRelatedPosts.ts
+++ b/src/utils/getRelatedPosts.ts
@@ -1,0 +1,37 @@
+import type { CollectionEntry } from "astro:content";
+import { slugifyAll } from "./slugify";
+
+/**
+ * Get related posts based on shared tags.
+ * @param currentPost - the post being viewed
+ * @param allPosts - all available posts (should be pre-filtered)
+ * @param limit - max number of related posts to return (default 3)
+ * @returns related posts sorted by tag overlap score, limited to `limit`
+ */
+export function getRelatedPosts(
+  currentPost: CollectionEntry<"liveBlog">,
+  allPosts: CollectionEntry<"liveBlog">[],
+  limit = 3
+): CollectionEntry<"liveBlog">[] {
+  const currentTags = new Set(slugifyAll(currentPost.data.tags ?? []));
+
+  return allPosts
+    .filter(post => {
+      // Exclude self
+      if (post.id === currentPost.id) return false;
+      // Only published posts (no drafts)
+      if (post.data.draft) return false;
+      // Must share at least one tag
+      const postTags = slugifyAll(post.data.tags ?? []);
+      return postTags.some(tag => currentTags.has(tag));
+    })
+    .map(post => {
+      // Score = number of shared tags
+      const postTags = slugifyAll(post.data.tags ?? []);
+      const score = postTags.filter(tag => currentTags.has(tag)).length;
+      return { post, score };
+    })
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map(({ post }) => post);
+}


### PR DESCRIPTION
## Summary

Adds crawlable related-post links to post pages using shared-tag scoring. This gives search engines and AI crawlers topical context instead of only chronological prev/next navigation.

## Changes

| File | Change |
|------|--------|
| `src/utils/getRelatedPosts.ts` | New utility: scores posts by tag overlap count, filters drafts/self, returns top N |
| `src/components/RelatedPosts.astro` | Renders related posts as crawlable `<a href>` links |
| `src/layouts/PostDetails.astro` | Imports and renders `<RelatedPosts>` before prev/next nav, wrapped in `data-pagefind-ignore` |
| `src/styles/global.css` | Adds `.related-posts` spacing |

## Acceptance criteria (issue #32)

- Post pages render crawlable related-post links when related posts exist -- met
- Related blocks do not include drafts -- met (draft filter in getRelatedPosts)
- Links are normal `<a href>` anchors -- met
- Sitemap includes any new topic/index routes -- existing `/tags/` routes unchanged
- Build passes -- verified (lint + astro build)

## Verification commands

```bash
pnpm run lint    # pass
pnpm run build  # pass
```

## Path boundary

app/source-code-touching

## Related issue

Closes #32
