### PR TITLE
Posts archive field-notes positioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",
     "preview": "astro preview",

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -32,6 +32,12 @@ const totalPages = Math.ceil(sortedPosts.length / pageSize);
 const start = (currentPage - 1) * pageSize;
 const end = start + pageSize;
 const paginatedPosts = sortedPosts.slice(start, end);
+const postsDeck =
+  "Field notes on agentic systems, governance, protocols, provenance, IP intelligence, continuity, and the operator work that turns AI output into shipped proof.";
+const postsIntro =
+  "Read these as a developing operating manual. Some pieces are tactical checklists. Some are system maps. Some are arguments about where AI-native work is actually bottlenecked: not in model access, but in authority, review, memory, handoffs, and accountability.";
+const postsMetadataDescription =
+  "Essays and field notes from Matt Berryhill on agent governance, AI-native workflows, protocol boundaries, continuity layers, IP intelligence, and shipped-work proof.";
 
 // Create page object similar to Astro's paginate
 const page = {
@@ -51,15 +57,22 @@ const page = {
 };
 const jsonLd = buildCollectionPageJsonLd({
   title: `Posts | ${SITE.title}`,
-  description: "All the articles I've posted.",
+  description: postsMetadataDescription,
   url: new URL(Astro.url.pathname, Astro.url.origin).href,
   isPartOf: SITE.title,
 });
 ---
 
-<Layout title={`Posts | ${SITE.title}`} jsonLd={jsonLd}>
+<Layout
+  title={`Posts | ${SITE.title}`}
+  description={postsMetadataDescription}
+  jsonLd={jsonLd}
+>
   <Header />
-  <Main pageTitle="Posts" pageDesc="All the articles I've posted.">
+  <Main pageTitle="Posts" pageDesc={postsDeck}>
+    <p class="text-skin-base mb-8 max-w-3xl text-lg leading-8">
+      {postsIntro}
+    </p>
     <ul class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
       {page.data.map(data => <Card variant="h3" {...data} />)}
     </ul>

--- a/tests/postsLlmsPositioning.test.mjs
+++ b/tests/postsLlmsPositioning.test.mjs
@@ -1,0 +1,98 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { SITE } from "../src/config.ts";
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(error);
+  }
+}
+
+function assertSourceIncludesCollapsedWhitespace(source, expected) {
+  assert.match(source.replace(/\s+/g, " "), new RegExp(escapeRegExp(expected)));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const postsPageSource = readFileSync(
+  new URL("../src/pages/posts/page/[page].astro", import.meta.url),
+  "utf8"
+);
+const llmsRouteSource = readFileSync(
+  new URL("../src/pages/llms.txt.ts", import.meta.url),
+  "utf8"
+);
+
+const expectedPostsCopy = {
+  title: "Posts",
+  deck:
+    "Field notes on agentic systems, governance, protocols, provenance, IP intelligence, continuity, and the operator work that turns AI output into shipped proof.",
+  intro:
+    "Read these as a developing operating manual. Some pieces are tactical checklists. Some are system maps. Some are arguments about where AI-native work is actually bottlenecked: not in model access, but in authority, review, memory, handoffs, and accountability.",
+  metadata:
+    "Essays and field notes from Matt Berryhill on agent governance, AI-native workflows, protocol boundaries, continuity layers, IP intelligence, and shipped-work proof.",
+};
+
+const expectedLlmsDescription =
+  "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
+
+const forbiddenLlmsClaims = [
+  "MCP server",
+  "telemetry product",
+  "fleet dashboard",
+  "production queue",
+  "API surface",
+];
+
+test("posts index source renders the approved title, deck, and intro copy", () => {
+  assert.match(postsPageSource, /pageTitle=\"Posts\"/);
+  assertSourceIncludesCollapsedWhitespace(postsPageSource, expectedPostsCopy.deck);
+  assertSourceIncludesCollapsedWhitespace(postsPageSource, expectedPostsCopy.intro);
+});
+
+test("posts index metadata uses the approved description", () => {
+  assertSourceIncludesCollapsedWhitespace(postsPageSource, expectedPostsCopy.metadata);
+  assert.doesNotMatch(postsPageSource, /All the articles I've posted\./);
+});
+
+test("posts index keeps pagination and card rendering intact", () => {
+  assert.match(postsPageSource, /getSortedPosts\(posts\)/);
+  assert.match(postsPageSource, /paginatedPosts = sortedPosts\.slice\(start, end\)/);
+  assert.match(postsPageSource, /<Card variant=\"h3\" \{\.\.\.data\} \/>/);
+  assert.match(postsPageSource, /<Pagination \{page\} \/>/);
+});
+
+test("llms.txt route is source-backed and uses the approved safe description", () => {
+  assert.equal(SITE.desc, expectedLlmsDescription);
+  assert.match(llmsRouteSource, /export const GET/);
+  assert.match(llmsRouteSource, /getLiveCollection\(\"liveBlog\"\)/);
+  assert.match(llmsRouteSource, /Representative posts/);
+  assert.match(llmsRouteSource, /SITE\.desc/);
+});
+
+test("llms.txt source does not invent forbidden product or fleet claims", () => {
+  for (const forbidden of forbiddenLlmsClaims) {
+    assert.equal(
+      llmsRouteSource.includes(forbidden),
+      false,
+      `unexpected llms.txt claim: ${forbidden}`
+    );
+  }
+});
+
+console.log(`PASS ${passed} FAIL ${failed}`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Closes #53

Source issue: https://github.com/berryhill/bd-site/issues/53

Classification: frontend; content/brand-surface; agent-facing-discovery-surface.

Prior PR audit / decision:
- Re-ran prior PR audit across all states before pushing/updating this step.
- Existing clean open PR for issue #53 and head branch `feature/issue-53-posts-llms-copy`: #65.
- No contaminated or closed replacement PR was found for this issue/head branch.
- Decision: update clean open PR #65 rather than create a duplicate replacement PR.

Branch/base audit:
```text
$ git fetch --prune origin
$ if git show-ref --verify --quiet refs/remotes/origin/dev; then echo dev; else echo main; fi
main

$ git rev-list --left-right --count origin/main...HEAD
0	1

$ git merge-base --is-ancestor origin/main HEAD; echo merge_base_ancestor_exit=$?
merge_base_ancestor_exit=0
```

Summary of code changes:
- Updates the posts archive page metadata, deck, intro copy, and CollectionPage JSON-LD description toward the requested field-notes framing.
- Keeps the posts archive as a brand surface for agentic-first development, AI systems, automation, crypto markets, and creative systems rather than generic blog/archive copy.
- Adds `tests/postsLlmsPositioning.test.mjs` to lock the posts index copy and verify `/llms.txt` stays aligned with field-notes/operator framing.
- Wires the new positioning test into `pnpm test` in `package.json`.

Doc reconciliation actions:
- Reviewed the repo docs/source relationship and kept the change scoped to implementation plus regression coverage.
- No human-facing docs required changes for this phase because the implementation already matches the current `.otoxan` and CLAUDE guidance around brand positioning and agent-facing surfaces.
- Preserved the known docs/source boundary: `build` remains `astro build`; no Pagefind, CI, Docker, deployment, or API behavior changed.

Destructive-diff guard output:
```text
$ git diff --name-status origin/main...HEAD
M	package.json
M	src/pages/posts/page/[page].astro
A	tests/postsLlmsPositioning.test.mjs

$ git diff --stat origin/main...HEAD
 package.json                        |  2 +-
 src/pages/posts/page/[page].astro   | 19 +++++--
 tests/postsLlmsPositioning.test.mjs | 98 +++++++++++++++++++++++++++++++++++++
 3 files changed, 115 insertions(+), 4 deletions(-)
```

Validation:
```text
$ pnpm test
PASS 7 FAIL 0
PASS 5 FAIL 0
PASS 5 FAIL 0
PASS 6 FAIL 0
PASS 7 FAIL 0
PASS 4 FAIL 0
PASS 4 FAIL 0
PASS 5 FAIL 0

$ pnpm run lint
eslint .

$ pnpm run format:check
All matched files use Prettier code style!

$ pnpm run build
astro build
[build] Complete!
```

Local runtime note: validation ran in this task worktree with Node `v22.22.3` and pnpm `11.1.3`; CI remains the reviewer-facing baseline from `.github/workflows/ci.yml` (Node 20, pnpm 10.11.1).
