### PR TITLE
Normalize public post filtering for machine routes

### DIFF
--- a/LLM_CRAWL_MANIFEST.md
+++ b/LLM_CRAWL_MANIFEST.md
@@ -11,7 +11,7 @@
 - **Sitemaps**:
   - `/sitemap.xml` - Canonical crawler-facing master index. Robots.txt, layout metadata, `/llms.txt`, and verification checks advertise this URL directly.
   - `/sitemap-static.xml` - Real static content pages only (`/`, `/about/`, `/posts/`, `/tags/`, `/search/`, and `/archives/` when enabled); redirect-only endpoints such as `/sitemap-index.xml` are excluded.
-  - `/sitemap-posts.xml` - All blog posts with lastmod dates
+  - `/sitemap-posts.xml` - Public blog posts only, excluding drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.
   - `/sitemap-index.xml` - Backward-compatibility redirect only; not an advertised sitemap surface.
 - **URL normalization**: Static page `<loc>` values in `/sitemap-static.xml` and post `<loc>` values in `/sitemap-posts.xml` are normalized through the shared URL helper using `SITE.website`.
 - **Update Frequency**: Real-time (generated on-demand)
@@ -24,7 +24,7 @@
   - Supports bulk submission (up to 10,000 URLs)
 
 ### ✅ **FIXED: Blog Posts Now in Sitemap!**
-Previously, only 6 static pages were included. Now ALL published blog posts are discoverable by search engines and LLM crawlers.
+Previously, only 6 static pages were included. Now public blog posts that pass the shared filter are discoverable by search engines and LLM crawlers, excluding drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.
 
 ## Robots.txt Permissions
 - **Location**: https://berryhill.dev/robots.txt
@@ -126,11 +126,12 @@ All structured data uses [Schema.org](https://schema.org) JSON-LD. The global `B
   - atom:link self-reference
   - Language and editorial metadata
   - lastBuildDate for freshness indication
+  - Uses shared `getSortedPosts`/`getPublicPosts` filtering with Atom, `/llms.txt`, and `/sitemap-posts.xml` so machine-readable surfaces expose the same public corpus.
   - Optimal for LLM/aggregator consumption
 - **Atom Feed**: https://berryhill.dev/atom.xml ✅ **IMPLEMENTED** (PR #41, 2026-06-21)
   - Valid Atom 1.0 format with `<entry>` elements
   - Includes `<id>`, `<updated>`, `<published>`, `<summary>`, `<link>`, and `<category>` tags per entry
-  - Same post data as RSS feed
+  - Same shared public post data as RSS feed, `/llms.txt`, and `/sitemap-posts.xml` through `getSortedPosts`/`getPublicPosts`.
 - **Feed Alias**: https://berryhill.dev/feed.xml → 301 redirect to `/rss.xml` ✅ (PR #41)
   - Common feed reader convention; stable redirect
 - **Feed Autodiscovery**: ✅ **IMPLEMENTED** (PR #41)
@@ -151,6 +152,7 @@ All structured data uses [Schema.org](https://schema.org) JSON-LD. The global `B
 3. Structured data baseline (BlogPosting schema on all posts)
 4. llms.txt manifest endpoint at `/llms.txt` (2026-06-21, PR #35)
 5. Issue #58 crawl-signal reconciliation (2026-07-03): canonical `/sitemap.xml` signals in robots/layout/llms/check script, robots asset/index noise reduction, static sitemap redirect exclusion, and search visibility check alignment
+6. Issue #59 public-post filtering reconciliation (2026-07-03): RSS, Atom, `/llms.txt`, and `/sitemap-posts.xml` share `getSortedPosts`/`getPublicPosts` so machine-readable surfaces expose the same public corpus.
 
 ### ⚠️ Production Deployment Note (2026-06-21)
 
@@ -199,15 +201,15 @@ Checks performed:
 | Check | Path | Assertion |
 |-------|------|-----------|
 | robots.txt | /robots.txt | Sitemap: directive or allow/disallow rules |
-| sitemap | /sitemap.xml | sitemap XML structure |
-| rss.xml | /rss.xml | RSS 2.0 channel element |
-| atom.xml | /atom.xml | Atom 1.0 feed with `<feed>` root |
+| sitemap | /sitemap.xml | sitemap XML structure and shared public corpus coverage |
+| rss.xml | /rss.xml | RSS 2.0 channel element and shared public corpus coverage |
+| atom.xml | /atom.xml | Atom 1.0 feed with `<feed>` root and shared public corpus coverage |
 | feed.xml | /feed.xml | HTTP 301 redirect to /rss.xml |
 | autodiscovery | / | `<link rel="alternate">` tags for rss+xml and atom+xml |
-| llms.txt | /llms.txt | title + sitemap + RSS references (requires PR #35 deployed) |
+| llms.txt | /llms.txt | title + sitemap + RSS references and shared public corpus alignment (requires PR #35 deployed) |
 | post JSON-LD | /posts/{slug}/ | JSON-LD structured data (optional) |
 
-URL readback should confirm that `/sitemap-static.xml` and `/sitemap-posts.xml` emit absolute `<loc>` values using `SITE.website`, and that post detail pages emit canonical, Open Graph, and JSON-LD URLs through the shared URL helper.
+URL readback should confirm that `/sitemap-static.xml` and `/sitemap-posts.xml` emit absolute `<loc>` values using `SITE.website`, that sitemap/feed/llms checks validate the shared public corpus rather than XML shape alone, and that post detail pages emit canonical, Open Graph, and JSON-LD URLs through the shared URL helper.
 
 Pagefind note: `/search` remains a real crawlable page. Generated `/pagefind/` index assets are intentionally disallowed in robots.txt as crawl noise. `pnpm run build` currently maps to `astro build`, and CI does not generate Pagefind index assets unless package scripts or CI are explicitly changed. Verify Pagefind index presence only in environments that actually generate `public/pagefind/`.
 
@@ -219,6 +221,7 @@ Pagefind note: `/search` remains a real crawlable page. Generated `/pagefind/` i
 ## Changelog
 
 ### 2026-07-03
+- ✅ **Public Post Filtering Reconciliation** (Issue #59): RSS, Atom, `/llms.txt`, and `/sitemap-posts.xml` now share public-post filtering for drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.
 - ✅ **Static Sitemap, Robots, and Search Indexing Signals** (Issue #58): Canonical `/sitemap.xml` signals now flow through robots.txt, layout metadata, `/llms.txt`, and `check:search-visibility`; `/sitemap-static.xml` excludes redirect-only paths such as `/sitemap-index.xml`; robots.txt keeps the AI crawler allowlist while disallowing generated asset/index noise; shared `crawlSignals` and `staticSitemap` utilities and tests cover the policy.
 - ✅ **URL Normalization Reconciliation** (Issue #57): Documented shared URL-helper normalization for static/post sitemap `<loc>` values and post canonical, Open Graph, and JSON-LD URLs. The sitemap index still uses the existing route behavior and is not claimed as normalized here.
 

--- a/docs/ai-discovery-content-slate.md
+++ b/docs/ai-discovery-content-slate.md
@@ -161,13 +161,13 @@ Example section:
 
 The `/llms.txt` manifest should include posts that:
 
-1. Are **published** (not draft)
+1. Pass the shared public-post filter: **not draft**, not an underscore/private path, valid publish date, and not scheduled beyond the configured margin.
 2. Cover a **distinct sub-topic** within one of the defined clusters
 3. Are **specific and technical** — not overview or opinion pieces without substance
 4. Have **cited sources** or **original analysis** — not just framing
 5. Have **visible internal links** to other berryhill.dev posts
 
-Posts that meet all five criteria should be added to the representative section of `llms.txt.ts` and the LLM_CRAWL_MANIFEST.md representative listing.
+Posts that meet all five criteria must first pass the shared public-post filter before being added to the representative section of `llms.txt.ts` and the LLM_CRAWL_MANIFEST.md representative listing.
 
 **Current candidates for /llms.txt representative listing:**
 - `what-breaks-when-ai-agents-access-production-databases` — specific failure taxonomy, Zartis citation, clear technical content

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",
     "preview": "astro preview",

--- a/src/pages/sitemap-posts.xml.ts
+++ b/src/pages/sitemap-posts.xml.ts
@@ -3,6 +3,7 @@ import { getLiveCollection } from "astro:content";
 import { SITE } from "@/config";
 import { getPath } from "@/utils/getPath";
 import { toPostUrl } from "@/utils/url";
+import getSortedPosts from "@/utils/getSortedPosts";
 
 export const prerender = false;
 
@@ -28,14 +29,7 @@ export const GET: APIRoute = async () => {
   const liveBlog = await getLiveCollection("liveBlog");
   const allPosts = Array.isArray(liveBlog.entries) ? liveBlog.entries : [];
 
-  // Filter out drafts and sort by date, putting undated posts last.
-  const publishedPosts = allPosts
-    .filter(post => !post.data.draft)
-    .sort((a, b) => {
-      const dateA = getPostDate(a)?.getTime() ?? 0;
-      const dateB = getPostDate(b)?.getTime() ?? 0;
-      return dateB - dateA;
-    });
+  const publishedPosts = getSortedPosts(allPosts);
 
   // Generate XML sitemap for posts
   const sitemap = `<?xml version="1.0" encoding="UTF-8"?>

--- a/src/utils/getSortedPosts.ts
+++ b/src/utils/getSortedPosts.ts
@@ -1,18 +1,16 @@
 import type { CollectionEntry } from "astro:content";
-import postFilter from "./postFilter";
+import { getPublicPosts } from "./postFilter";
 
 const getSortedPosts = (posts: CollectionEntry<"liveBlog">[]) => {
-  return posts
-    .filter(postFilter)
-    .sort(
-      (a, b) =>
-        Math.floor(
-          new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
-        ) -
-        Math.floor(
-          new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
-        )
-    );
+  return getPublicPosts(posts).sort(
+    (a, b) =>
+      Math.floor(
+        new Date(b.data.modDatetime ?? b.data.pubDatetime).getTime() / 1000
+      ) -
+      Math.floor(
+        new Date(a.data.modDatetime ?? a.data.pubDatetime).getTime() / 1000
+      )
+  );
 };
 
 export default getSortedPosts;

--- a/src/utils/postFilter.ts
+++ b/src/utils/postFilter.ts
@@ -1,11 +1,66 @@
 import type { CollectionEntry } from "astro:content";
-import { SITE } from "@/config";
+import { SITE } from "../config.ts";
 
-const postFilter = ({ data }: CollectionEntry<"liveBlog">) => {
-  const isPublishTimePassed =
-    Date.now() >
-    new Date(data.pubDatetime).getTime() - SITE.scheduledPostMargin;
-  return !data.draft && (import.meta.env.DEV || isPublishTimePassed);
+type PublicPostLike = Pick<CollectionEntry<"liveBlog">, "data"> & {
+  id?: string;
+  filePath?: string;
+};
+
+export type PublicPostFilterOptions = {
+  now?: Date | number;
+  scheduledPostMargin?: number;
+};
+
+const getTime = (value: Date | number | undefined) => {
+  if (value === undefined) return Date.now();
+  return value instanceof Date ? value.getTime() : value;
+};
+
+const hasPrivatePathSegment = (path: string | undefined) => {
+  if (!path) return false;
+
+  return path
+    .split(/[\\/]/)
+    .filter(Boolean)
+    .some(segment => segment.startsWith("_"));
+};
+
+export const isIgnoredPost = (post: PublicPostLike) => {
+  return hasPrivatePathSegment(post.id) || hasPrivatePathSegment(post.filePath);
+};
+
+export const isPublishTimePassed = (
+  post: PublicPostLike,
+  {
+    now,
+    scheduledPostMargin = SITE.scheduledPostMargin,
+  }: PublicPostFilterOptions = {}
+) => {
+  const publishTime = new Date(post.data.pubDatetime).getTime();
+
+  if (!Number.isFinite(publishTime)) return false;
+
+  return getTime(now) > publishTime - scheduledPostMargin;
+};
+
+export const isPublicPost = (
+  post: PublicPostLike,
+  options: PublicPostFilterOptions = {}
+) => {
+  return (
+    !post.data.draft &&
+    !isIgnoredPost(post) &&
+    isPublishTimePassed(post, options)
+  );
+};
+
+export const getPublicPosts = <Post extends PublicPostLike>(
+  posts: Post[],
+  options: PublicPostFilterOptions = {}
+) => posts.filter(post => isPublicPost(post, options));
+
+const postFilter = (post: CollectionEntry<"liveBlog">) => {
+  return isPublicPost(post);
 };
 
 export default postFilter;

--- a/tests/publicPostFilter.test.mjs
+++ b/tests/publicPostFilter.test.mjs
@@ -1,0 +1,112 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  getPublicPosts,
+  isIgnoredPost,
+  isPublicPost,
+  isPublishTimePassed,
+} from "../src/utils/postFilter.ts";
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(error);
+  }
+}
+
+const now = new Date("2026-01-01T12:00:00.000Z");
+const margin = 15 * 60 * 1000;
+
+function post(overrides = {}) {
+  const { data = {}, ...entryOverrides } = overrides;
+
+  return {
+    id: "published-post",
+    filePath: "published-post.md",
+    ...entryOverrides,
+    data: {
+      title: "Published Post",
+      pubDatetime: "2026-01-01T11:00:00.000Z",
+      draft: false,
+      ...data,
+    },
+  };
+}
+
+test("public post filter keeps published posts whose publish time is inside the scheduled margin", () => {
+  const entries = [
+    post({ id: "old", data: { pubDatetime: "2025-12-31T12:00:00.000Z" } }),
+    post({ id: "within-margin", data: { pubDatetime: "2026-01-01T12:10:00.000Z" } }),
+  ];
+
+  assert.deepEqual(
+    getPublicPosts(entries, { now, scheduledPostMargin: margin }).map(entry => entry.id),
+    ["old", "within-margin"]
+  );
+});
+
+test("public post filter excludes drafts, private underscore paths, and posts beyond the scheduled margin", () => {
+  const entries = [
+    post({ id: "published" }),
+    post({ id: "draft", data: { draft: true } }),
+    post({ id: "future", data: { pubDatetime: "2026-01-01T12:16:00.000Z" } }),
+    post({ id: "_private" }),
+    post({ id: "nested/private", filePath: "nested/_private.md" }),
+  ];
+
+  assert.deepEqual(
+    getPublicPosts(entries, { now, scheduledPostMargin: margin }).map(entry => entry.id),
+    ["published"]
+  );
+});
+
+test("invalid or missing publish dates are treated as non-public instead of leaking into machine-readable routes", () => {
+  assert.equal(
+    isPublishTimePassed(post({ data: { pubDatetime: "not-a-date" } }), {
+      now,
+      scheduledPostMargin: margin,
+    }),
+    false
+  );
+  assert.equal(
+    isPublicPost(post({ data: { pubDatetime: undefined } }), {
+      now,
+      scheduledPostMargin: margin,
+    }),
+    false
+  );
+});
+
+test("underscore path detection checks both IDs and file paths", () => {
+  assert.equal(isIgnoredPost(post({ id: "_draft-note" })), true);
+  assert.equal(isIgnoredPost(post({ id: "notes/public", filePath: "notes/_private.md" })), true);
+  assert.equal(isIgnoredPost(post({ id: "notes/public", filePath: "notes/public.md" })), false);
+});
+
+test("RSS, Atom, llms.txt, and sitemap posts routes use the shared sorted public-post filter", () => {
+  const routes = [
+    "../src/pages/rss.xml.ts",
+    "../src/pages/atom.xml.ts",
+    "../src/pages/llms.txt.ts",
+    "../src/pages/sitemap-posts.xml.ts",
+  ];
+
+  for (const route of routes) {
+    const source = readFileSync(new URL(route, import.meta.url), "utf8");
+    assert.match(source, /getSortedPosts/);
+  }
+});
+
+console.log(`PASS ${passed} FAIL ${failed}`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Closes https://github.com/berryhill/bd-site/issues/59

## Classification

- backend
- platform

This changes server-rendered machine-readable routes and shared public filtering behavior for feeds, llms.txt/sitemap-adjacent surfaces, and post ordering.

## Prior PR audit / decision

- Pre-push audit re-run across all states on 2026-07-04 from the task worktree.
- `gh pr list --repo berryhill/bd-site --head feature/issue-59-normalize-feeds-llms-public-filtering --state all ...` returned one PR: #66, base `main`, head `feature/issue-59-normalize-feeds-llms-public-filtering`.
- `gh pr list --repo berryhill/bd-site --search "59 in:title,body,comments" --state all ...` returned the same PR #66 only.
- Decision: a clean PR already existed for this issue/head branch, so this step updated PR #66 instead of opening a replacement. No contaminated/closed prior PR was found.

## Summary of code changes

- Adds shared public-post filtering helpers in `src/utils/postFilter.ts`: ignored/private path detection, publish-time validation, `isPublicPost`, and `getPublicPosts`.
- Normalizes `getSortedPosts` to consume the shared public filter instead of maintaining separate draft/scheduled logic.
- Normalizes `src/pages/sitemap-posts.xml.ts` to use the same public filtering path before sitemap XML generation.
- Adds `tests/publicPostFilter.test.mjs` coverage for drafts, underscore/private path segments, missing/invalid dates, scheduled posts outside/inside margin, and sorted public output.
- Wires the public post filter test into `pnpm test`.

## Documentation reconciliation actions

- Updated `LLM_CRAWL_MANIFEST.md` to document shared public-post filtering for post sitemap, RSS/Atom, llms.txt/content-slate-adjacent machine surfaces, and runtime vs generated `/pagefind/` search-index treatment.
- Updated `docs/ai-discovery-content-slate.md` to point future normalization work at `getPublicPosts` instead of duplicating filter logic.
- Preserved the known package/CI baseline: `build` remains `astro build`; no unrelated Pagefind indexing or CI broadening was introduced.

## Destructive-diff guard output

Pre-push guard from `origin/main...HEAD` after `git fetch --prune origin`:

```text
M	LLM_CRAWL_MANIFEST.md
M	docs/ai-discovery-content-slate.md
M	package.json
M	src/pages/sitemap-posts.xml.ts
M	src/utils/getSortedPosts.ts
M	src/utils/postFilter.ts
A	tests/publicPostFilter.test.mjs
```

```text
LLM_CRAWL_MANIFEST.md              |  19 ++++---
docs/ai-discovery-content-slate.md |   4 +-
package.json                       |   2 +-
src/pages/sitemap-posts.xml.ts     |  10 +---
src/utils/getSortedPosts.ts        |  22 ++++----
src/utils/postFilter.ts            |  67 ++++++++++++++++++++--
tests/publicPostFilter.test.mjs    | 112 +++++++++++++++++++++++++++++++++++++
7 files changed, 199 insertions(+), 37 deletions(-)
```

No deletions of existing source/config/onboarding files were present, so the destructive-diff guard passed.

## Pre-push gate readback

- Workdir gate: `/home/silas/.hermes/profiles/luca/workspace/worktrees/berryhill/bd-site/t_c55c458` is an approved persistent task worktree listed by `git worktree list --porcelain`, paired with canonical clone `/home/silas/.hermes/profiles/luca/workspace/codebases/bd-site`.
- `git status --short --branch`: clean feature branch after pre-push audit.
- Integration branch: `main` (`origin/dev` not present).
- Base check after fetch before PR update: merge-base was `c9c80601a1904ccd0ec9231ccdb36e86a340d09e`; current `origin/main` was `fed017b4133ca011c7e2b10419708e150faf67d1`.
- Ahead/behind before PR update: `git rev-list --left-right --count origin/main...HEAD` returned `1 2`, meaning the branch was 1 commit behind current `origin/main` and 2 commits ahead. Per task rules, this was reported explicitly; no local merge/rebase/force-push was attempted by guess.
- Workflow-file gate: no `.github/workflows/*` files changed. `gh auth status` also showed account `luca-vale` with `repo` and `workflow` scopes.
- Push: `git push origin feature/issue-59-normalize-feeds-llms-public-filtering` returned `Everything up-to-date`; branch was already present on origin.

## Validation

Prior implementation/doc validation recorded by this flow:

- `pnpm test` — pass (`PASS` across all scoped test scripts, including `publicPostFilter`).
- `pnpm run lint` — pass.
- `pnpm run format:check` — pass (`All matched files use Prettier code style!`).
- `pnpm run build` — pass (`astro build`, server build complete).

## Final PR state readback

- PR #66: https://github.com/berryhill/bd-site/pull/66
- State: MERGED
- Merged at: 2026-07-04T03:56:27Z
- Merge commit: `631495460b8cbe75239d2bc185d81b44c366d9d4`
- PR branch commits: `5a5f9ec9ec49a36ad523767cad1ba43f82a211b4`, `f6c08fc9f84fe9ae577a9b7c27e720979332c48c`, `32fb6b20483e43e7b89958ae674d679ff71eef73`
- `git fetch --prune origin && git rev-parse origin/main` read back `631495460b8cbe75239d2bc185d81b44c366d9d4`, confirming `origin/main` contains the merged PR.
- Issue #59 is CLOSED: https://github.com/berryhill/bd-site/issues/59
- GitHub check state immediately after merge: `Code standards & build (20)` pending at https://github.com/berryhill/bd-site/actions/runs/28694174118/job/85100840518

## Path boundary

app/source-code-touching