### PR TITLE
feat: add terminal brand surfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:seo-crawl-surface": "node scripts/checkSeoCrawlSurface.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",

--- a/src/components/Card.astro
+++ b/src/components/Card.astro
@@ -9,154 +9,149 @@ export interface Props extends CollectionEntry<"liveBlog"> {
 
 const { variant = "h2", data, id, filePath } = Astro.props;
 
-const { title, description, pubDatetime, modDatetime, timezone, ogImage } =
-  data;
+const { title, description, pubDatetime, modDatetime, timezone, tags } = data;
+const href = getPath(id, filePath);
+const lane = tags?.[0] ?? "field-note";
+const filename = `${id}.md`;
 ---
 
-<li class="card-fancy">
-  <div class="card-glow-effect"></div>
-  <div class="card-content">
-    <div class="card-kicker">Field note</div>
+<li class="terminal-post-card">
+  <a href={href} class="terminal-post-card__link" aria-label={`Read ${title}`}>
+    <div class="terminal-post-card__meta">
+      <span class="terminal-post-card__lane">{lane}/</span>
+      <Datetime
+        {pubDatetime}
+        {modDatetime}
+        {timezone}
+        class="terminal-post-card__date"
+      />
+    </div>
+
+    <div class="terminal-post-card__path">{filename}</div>
+
     {
-      ogImage && (
-        <div class="card-image-wrapper">
-          <img src={ogImage} alt={title} class="card-image" />
-        </div>
+      variant === "h2" ? (
+        <h2 class="terminal-post-card__title">{title}</h2>
+      ) : (
+        <h3 class="terminal-post-card__title">{title}</h3>
       )
     }
 
-    <a href={getPath(id, filePath)} class="card-title-link">
-      {
-        variant === "h2" ? (
-          <h2 class="card-title">{title}</h2>
-        ) : (
-          <h3 class="card-title">{title}</h3>
-        )
-      }
-    </a>
-
-    <Datetime {pubDatetime} {modDatetime} {timezone} class="card-date" />
-
-    <p class="card-description">{description}</p>
-
-    <div class="card-corner-accent"></div>
-  </div>
+    <p class="terminal-post-card__description">{description}</p>
+    <span class="terminal-post-card__cta">open artifact →</span>
+  </a>
 </li>
 
 <style>
-  .card-fancy {
-    position: relative;
+  .terminal-post-card {
     height: 100%;
-    border-radius: 12px;
+    list-style: none;
   }
 
-  .card-glow-effect {
-    display: none;
-  }
-
-  .card-content {
+  .terminal-post-card__link {
     position: relative;
-    height: 100%;
     display: flex;
-    flex-direction: column;
-    padding: 1.35rem;
-    background: var(--bg-secondary);
-    border: 1px solid var(--border);
-    border-radius: 12px;
-    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.35);
-    transition: all 0.2s ease;
-  }
-
-  .card-fancy:hover .card-content {
-    border-color: var(--accent);
-    transform: translateY(-2px);
-  }
-
-  .card-kicker {
-    margin-bottom: 0.85rem;
-    color: var(--accent);
-    font-family:
-      ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono",
-      "Courier New", monospace;
-    font-size: 0.72rem;
-    font-weight: 800;
-    letter-spacing: 0.14em;
-    line-height: 1;
-    text-transform: uppercase;
-  }
-
-  .card-title-link {
-    text-decoration: none;
-    display: block;
-    min-height: 6.1rem;
-    margin-bottom: 0.65rem;
-  }
-
-  .card-title {
-    font-size: clamp(1.08rem, 1rem + 0.35vw, 1.25rem);
-    font-weight: 700;
-    color: var(--foreground);
-    transition: color 0.2s ease;
-    margin: 0;
-    line-height: 1.32;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-
-  .card-fancy:hover .card-title {
-    color: var(--accent);
-  }
-
-  .card-date {
-    font-size: 0.8rem;
-    opacity: 0.65;
-    margin-bottom: 0.85rem;
-    font-weight: 500;
-    display: block;
-  }
-
-  .card-description {
-    font-size: 0.9375rem;
-    color: var(--foreground-muted);
-    line-height: 1.7;
-    margin: 0;
-    display: -webkit-box;
-    -webkit-line-clamp: 4;
-    -webkit-box-orient: vertical;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    flex: 1;
-  }
-
-  @media (min-width: 768px) {
-    .card-content {
-      padding: 1.5rem;
-    }
-  }
-
-  .card-corner-accent {
-    display: none;
-  }
-
-  .card-image-wrapper {
-    width: 100%;
-    height: 200px;
-    overflow: hidden;
-    border-radius: 8px;
-    margin-bottom: 1rem;
-  }
-
-  .card-image {
-    width: 100%;
     height: 100%;
-    object-fit: cover;
-    transition: transform 0.3s ease;
+    min-height: 17rem;
+    flex-direction: column;
+    gap: 0.85rem;
+    border: 1px solid var(--terminal-border);
+    border-radius: 1rem;
+    padding: 1.1rem;
+    background:
+      linear-gradient(180deg, rgb(255 255 255 / 0.025), transparent),
+      var(--terminal-panel);
+    box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.06);
+    color: var(--terminal-fg);
+    text-decoration: none;
+    transition:
+      border-color 180ms ease,
+      transform 180ms ease,
+      background 180ms ease;
   }
 
-  .card-fancy:hover .card-image {
-    transform: scale(1.05);
+  .terminal-post-card__link::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    pointer-events: none;
+    background: radial-gradient(
+      circle at 18% 0%,
+      color-mix(in srgb, var(--terminal-accent) 10%, transparent),
+      transparent 34%
+    );
+    opacity: 0.75;
+  }
+
+  .terminal-post-card__link:hover,
+  .terminal-post-card__link:focus-visible {
+    border-color: color-mix(in srgb, var(--terminal-accent) 70%, transparent);
+    transform: translateY(-2px);
+    opacity: 1;
+  }
+
+  .terminal-post-card__meta,
+  .terminal-post-card__path,
+  .terminal-post-card__cta {
+    position: relative;
+    z-index: 1;
+    font-family: var(--terminal-font);
+  }
+
+  .terminal-post-card__meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    color: var(--terminal-muted);
+    font-size: 0.78rem;
+  }
+
+  .terminal-post-card__lane {
+    color: var(--terminal-warn);
+  }
+
+  .terminal-post-card__date {
+    color: var(--terminal-muted);
+    font-size: 0.78rem;
+  }
+
+  .terminal-post-card__path {
+    color: var(--terminal-accent);
+    font-size: 0.82rem;
+    overflow-wrap: anywhere;
+  }
+
+  .terminal-post-card__title {
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    color: var(--terminal-fg);
+    font-size: clamp(1.12rem, 1rem + 0.35vw, 1.34rem);
+    line-height: 1.25;
+    letter-spacing: -0.02em;
+  }
+
+  .terminal-post-card__description {
+    position: relative;
+    z-index: 1;
+    margin: 0;
+    color: var(--terminal-muted);
+    font-size: 0.94rem;
+    line-height: 1.65;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  .terminal-post-card__cta {
+    position: relative;
+    z-index: 1;
+    margin-top: auto;
+    color: var(--terminal-accent);
+    font-size: 0.82rem;
   }
 </style>

--- a/src/layouts/AboutLayout.astro
+++ b/src/layouts/AboutLayout.astro
@@ -1,7 +1,6 @@
 ---
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
-import Breadcrumb from "@/components/Breadcrumb.astro";
 import Layout from "./Layout.astro";
 import { SITE } from "@/config";
 import { buildPersonJsonLd } from "@/utils/structuredData";
@@ -28,15 +27,11 @@ const jsonLd = buildPersonJsonLd({
   jsonLd={jsonLd}
 >
   <Header />
-  <Breadcrumb />
-  <main id="main-content">
+  <main id="main-content" class="terminal-page px-4 pb-16 sm:px-6">
     <section
       id="about"
-      class="app-prose mx-auto mb-28 max-w-app px-4 prose-img:border-0"
+      class="app-prose terminal-prose-shell mx-auto mt-8 mb-12 max-w-5xl prose-img:border-0"
     >
-      <h1 class="mb-8 text-2xl tracking-wider sm:text-3xl">
-        {frontmatter.title}
-      </h1>
       <slot />
     </section>
   </main>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -105,6 +105,23 @@ const nextPost =
   currentPostIndex !== allPosts.length ? allPosts[currentPostIndex + 1] : null;
 
 const relatedPosts = getRelatedPosts(post, posts);
+const wordCount = (post.body || "").trim().split(/\s+/).filter(Boolean).length;
+const readMinutes = Math.max(1, Math.round(wordCount / 220));
+const lane = tags?.[0] ?? "field-note";
+const formatDate = (value: Date | string | undefined) => {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return String(value).slice(0, 10);
+  return date.toISOString().slice(0, 10);
+};
+const frontmatterPreview = [
+  ["title", title],
+  ["date", formatDate(pubDatetime)],
+  ["updated", formatDate(modDatetime)],
+  ["lane", lane],
+  ["read", `${readMinutes} min`],
+  ["status", "published"],
+].filter(([, value]) => Boolean(value));
 ---
 
 <Layout {...layoutProps}>
@@ -118,26 +135,52 @@ const relatedPosts = getRelatedPosts(post, posts);
     ]}
     data-pagefind-body
   >
-    <h1
-      transition:name={slugifyStr(title)}
-      class="inline-block text-2xl font-bold text-accent sm:text-3xl"
-    >
-      {title}
-    </h1>
-    <div class="my-2 flex items-center gap-2">
-      <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
-      <span
-        aria-hidden="true"
-        class:list={[
-          "max-sm:hidden",
-          { hidden: !SITE.editPost.enabled || hideEditPost },
-        ]}>|</span
+    <header class="terminal-shell mt-4 p-4 md:p-6">
+      <p class="terminal-path text-sm md:text-base">
+        cat ~/berryhill.dev/posts/{post.id}.md
+      </p>
+      <p
+        class="text-skin-muted mt-4 font-mono text-xs tracking-widest uppercase"
       >
-      <EditPost {hideEditPost} {post} class="max-sm:hidden" />
-    </div>
+        post.yaml
+      </p>
+      <pre
+        class="border-skin-line bg-skin-card mt-2 overflow-x-auto rounded-lg border p-4 text-xs leading-6"><code>{frontmatterPreview.map(([key, value]) => `${key}: ${value}`).join("\n")}</code></pre>
+      <p
+        class="text-skin-muted mt-5 font-mono text-xs tracking-widest uppercase"
+      >
+        essay · artifact
+      </p>
+      <h1
+        transition:name={slugifyStr(title)}
+        class="mt-2 max-w-4xl text-3xl font-bold tracking-tight md:text-5xl"
+      >
+        {title}
+      </h1>
+      <p class="text-skin-base mt-4 max-w-3xl text-lg leading-8">
+        {description}
+      </p>
+      <div class="operator-read mt-5 max-w-3xl">
+        <p class="text-skin-muted font-mono text-xs tracking-widest uppercase">
+          operator read
+        </p>
+        <p class="text-skin-base mt-2 text-sm leading-7">{description}</p>
+      </div>
+      <div class="mt-5 flex items-center gap-2">
+        <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
+        <span
+          aria-hidden="true"
+          class:list={[
+            "max-sm:hidden",
+            { hidden: !SITE.editPost.enabled || hideEditPost },
+          ]}>|</span
+        >
+        <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+      </div>
+    </header>
     <article
       id="article"
-      class="app-prose mx-auto mt-8 max-w-app prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"
+      class="app-prose terminal-article mx-auto mt-8 max-w-3xl prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"
     >
       <div set:html={htmlContent} />
     </article>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -40,24 +40,20 @@ const {
   hideEditPost,
 } = post.data;
 
-// Live collections don't support render(), so we manually parse markdown
 const htmlContent = await marked.parse(post.body || "");
 
 let ogImageUrl: string | undefined;
 
-// Determine OG image source
 if (typeof initOgImage === "string") {
-  ogImageUrl = initOgImage; // Remote OG image (absolute URL)
+  ogImageUrl = initOgImage;
 } else if (initOgImage?.src) {
-  ogImageUrl = initOgImage.src; // Local asset
+  ogImageUrl = initOgImage.src;
 }
 
-// Use dynamic OG image if enabled and no remote|local ogImage
 if (!ogImageUrl && SITE.dynamicOgImage) {
   ogImageUrl = `${getPath(post.id, post.filePath)}/index.png`;
 }
 
-// Resolve OG image URL (or fallback to SITE.ogImage / default `og.png`)
 const ogImage = ogImageUrl
   ? toAbsoluteSiteUrl(ogImageUrl, SITE.website)
   : undefined;
@@ -90,8 +86,6 @@ const layoutProps = {
   jsonLd,
 };
 
-/* ========== Prev/Next Posts ========== */
-
 const allPosts = posts.map(({ data: { title }, id, filePath }) => ({
   id,
   title,
@@ -99,10 +93,11 @@ const allPosts = posts.map(({ data: { title }, id, filePath }) => ({
 }));
 
 const currentPostIndex = allPosts.findIndex(a => a.id === post.id);
-
-const prevPost = currentPostIndex !== 0 ? allPosts[currentPostIndex - 1] : null;
+const prevPost = currentPostIndex > 0 ? allPosts[currentPostIndex - 1] : null;
 const nextPost =
-  currentPostIndex !== allPosts.length ? allPosts[currentPostIndex + 1] : null;
+  currentPostIndex >= 0 && currentPostIndex < allPosts.length - 1
+    ? allPosts[currentPostIndex + 1]
+    : null;
 
 const relatedPosts = getRelatedPosts(post, posts);
 const wordCount = (post.body || "").trim().split(/\s+/).filter(Boolean).length;
@@ -120,8 +115,15 @@ const frontmatterPreview = [
   ["updated", formatDate(modDatetime)],
   ["lane", lane],
   ["read", `${readMinutes} min`],
+  ["words", wordCount.toLocaleString()],
+  ["slug", post.id],
   ["status", "published"],
 ].filter(([, value]) => Boolean(value));
+const toc = Array.from((post.body || "").matchAll(/^##\s+(.+)$/gm))
+  .map(match => String(match[1]).replace(/#+$/, "").trim())
+  .filter(Boolean)
+  .slice(0, 8)
+  .map(label => ({ label, href: `#${slugifyStr(label)}` }));
 ---
 
 <Layout {...layoutProps}>
@@ -130,93 +132,115 @@ const frontmatterPreview = [
   <main
     id="main-content"
     class:list={[
-      "mx-auto w-full max-w-app px-4 pb-12",
+      "terminal-page w-full px-4 pb-12 sm:px-6",
       { "mt-8": !SITE.showBackButton },
     ]}
     data-pagefind-body
   >
-    <header class="terminal-shell mt-4 p-4 md:p-6">
-      <p class="terminal-path text-sm md:text-base">
-        cat ~/berryhill.dev/posts/{post.id}.md
-      </p>
-      <p
-        class="text-skin-muted mt-4 font-mono text-xs tracking-widest uppercase"
-      >
-        post.yaml
-      </p>
-      <pre
-        class="border-skin-line bg-skin-card mt-2 overflow-x-auto rounded-lg border p-4 text-xs leading-6"><code>{frontmatterPreview.map(([key, value]) => `${key}: ${value}`).join("\n")}</code></pre>
-      <p
-        class="text-skin-muted mt-5 font-mono text-xs tracking-widest uppercase"
-      >
-        essay · artifact
-      </p>
-      <h1
-        transition:name={slugifyStr(title)}
-        class="mt-2 max-w-4xl text-3xl font-bold tracking-tight md:text-5xl"
-      >
-        {title}
-      </h1>
-      <p class="text-skin-base mt-4 max-w-3xl text-lg leading-8">
-        {description}
-      </p>
-      <div class="operator-read mt-5 max-w-3xl">
-        <p class="text-skin-muted font-mono text-xs tracking-widest uppercase">
-          operator read
-        </p>
-        <p class="text-skin-base mt-2 text-sm leading-7">{description}</p>
+    <header class="terminal-shell mt-4">
+      <div class="terminal-chrome" aria-hidden="true">
+        <span class="terminal-dots">
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+          <span class="terminal-dot"></span>
+        </span>
+        <span>matt@berryhill: ~/berryhill.dev/posts/{post.id}.md</span>
+        <span>{readMinutes} min read</span>
       </div>
-      <div class="mt-5 flex items-center gap-2">
-        <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
-        <span
-          aria-hidden="true"
-          class:list={[
-            "max-sm:hidden",
-            { hidden: !SITE.editPost.enabled || hideEditPost },
-          ]}>|</span
+      <div class="terminal-body">
+        <p class="terminal-path text-sm md:text-base">
+          cat ~/berryhill.dev/posts/{post.id}.md
+        </p>
+        <p class="terminal-kicker mt-5">post.yaml</p>
+        <pre
+          class="terminal-panel mt-2 overflow-x-auto p-4 text-xs leading-6"><code>{frontmatterPreview.map(([key, value]) => `${key}: ${value}`).join("\n")}</code></pre>
+        <p class="terminal-kicker mt-6">essay · artifact</p>
+        <h1
+          transition:name={slugifyStr(title)}
+          class="mt-2 max-w-5xl text-4xl font-bold tracking-tight md:text-6xl"
         >
-        <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+          {title}
+        </h1>
+        <p class="text-skin-base mt-4 max-w-3xl text-lg leading-8">
+          {description}
+        </p>
+        <div class="operator-read mt-5 max-w-3xl">
+          <p class="terminal-kicker">operator read</p>
+          <p class="text-skin-base mt-2 text-sm leading-7">
+            Read this as a working artifact: what changed, what evidence
+            matters, where the system boundary sits, and what an operator should
+            do next.
+          </p>
+        </div>
+        <div class="mt-5 flex flex-wrap items-center gap-2 text-sm">
+          <Datetime {pubDatetime} {modDatetime} {timezone} size="lg" />
+          <span
+            aria-hidden="true"
+            class:list={[
+              "max-sm:hidden",
+              { hidden: !SITE.editPost.enabled || hideEditPost },
+            ]}>|</span
+          >
+          <EditPost {hideEditPost} {post} class="max-sm:hidden" />
+        </div>
       </div>
     </header>
-    <article
-      id="article"
-      class="app-prose terminal-article mx-auto mt-8 max-w-3xl prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"
-    >
-      <div set:html={htmlContent} />
-    </article>
 
-    <hr class="my-8 border-dashed" />
+    <div class="post-terminal-layout mt-8">
+      {
+        toc.length > 0 && (
+          <aside class="terminal-panel post-toc p-4" data-pagefind-ignore>
+            <p class="terminal-command text-sm">grep -n "^##" {post.id}.md</p>
+            <h2 class="mt-3 text-base font-bold">On this page</h2>
+            <ol class="mt-3 space-y-2 text-sm">
+              {toc.map(item => (
+                <li>
+                  <a href={item.href}>{item.label}</a>
+                </li>
+              ))}
+            </ol>
+          </aside>
+        )
+      }
 
-    <EditPost class="sm:hidden" {hideEditPost} {post} />
+      <article
+        id="article"
+        class="app-prose terminal-article terminal-prose-shell max-w-none prose-pre:bg-(--shiki-light-bg) dark:prose-pre:bg-(--shiki-dark-bg)"
+      >
+        <div set:html={htmlContent} />
+      </article>
+    </div>
 
-    <ul class="mt-4 mb-8 sm:my-8">
-      {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
-    </ul>
+    <div class="terminal-panel mt-8 p-4 md:p-5">
+      <EditPost class="sm:hidden" {hideEditPost} {post} />
 
-    <BackToTopButton />
+      <ul class="mt-2 mb-6 flex flex-wrap gap-2">
+        {tags.map(tag => <Tag tag={slugifyStr(tag)} tagName={tag} />)}
+      </ul>
 
-    <ShareLinks />
+      <BackToTopButton />
+      <ShareLinks />
+    </div>
 
-    <hr class="my-6 border-dashed" />
-
-    <div data-pagefind-ignore>
+    <div class="mt-8" data-pagefind-ignore>
       <RelatedPosts posts={relatedPosts} />
     </div>
 
-    <hr class="my-6 border-dashed" />
-
-    <!-- Previous/Next Post Buttons -->
-    <div data-pagefind-ignore class="grid grid-cols-1 gap-6 sm:grid-cols-2">
+    <nav
+      data-pagefind-ignore
+      class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2"
+      aria-label="Previous and next posts"
+    >
       {
         prevPost && (
           <a
             href={getPath(prevPost.id, prevPost.filePath)}
-            class="flex w-full gap-1 hover:opacity-75"
+            class="terminal-panel p-4 hover:opacity-100"
           >
-            <IconChevronLeft class="inline-block flex-none rtl:rotate-180" />
-            <div>
-              <span>Previous Post</span>
-              <div class="text-sm text-accent/85">{prevPost.title}</div>
+            <span class="terminal-kicker">previous</span>
+            <div class="text-skin-accent mt-2 flex gap-2">
+              <IconChevronLeft class="inline-block flex-none rtl:rotate-180" />
+              <span>{prevPost.title}</span>
             </div>
           </a>
         )
@@ -225,45 +249,60 @@ const frontmatterPreview = [
         nextPost && (
           <a
             href={getPath(nextPost.id, nextPost.filePath)}
-            class="flex w-full justify-end gap-1 text-end hover:opacity-75 sm:col-start-2"
+            class="terminal-panel p-4 text-end hover:opacity-100 sm:col-start-2"
           >
-            <div>
-              <span>Next Post</span>
-              <div class="text-sm text-accent/85">{nextPost.title}</div>
+            <span class="terminal-kicker">next</span>
+            <div class="text-skin-accent mt-2 flex justify-end gap-2">
+              <span>{nextPost.title}</span>
+              <IconChevronRight class="inline-block flex-none rtl:rotate-180" />
             </div>
-            <IconChevronRight class="inline-block flex-none rtl:rotate-180" />
           </a>
         )
       }
-    </div>
+    </nav>
   </main>
   <Footer />
 </Layout>
 
+<style>
+  .post-terminal-layout {
+    display: grid;
+    gap: 1.25rem;
+  }
+
+  @media (min-width: 1024px) {
+    .post-terminal-layout {
+      grid-template-columns: 16rem minmax(0, 1fr);
+      align-items: start;
+    }
+
+    .post-toc {
+      position: sticky;
+      top: 6rem;
+    }
+  }
+
+  .post-toc ol {
+    margin: 0;
+    padding-left: 1.2rem;
+  }
+</style>
+
 <script is:inline data-astro-rerun>
-  /** Create a progress indicator
-   *  at the top */
   function createProgressBar() {
-    // Create the main container div
     const progressContainer = document.createElement("div");
     progressContainer.className =
       "progress-container fixed top-0 z-10 h-1 w-full bg-background";
 
-    // Create the progress bar div
     const progressBar = document.createElement("div");
     progressBar.className = "progress-bar h-1 w-0 bg-accent";
     progressBar.id = "myBar";
 
-    // Append the progress bar to the progress container
     progressContainer.appendChild(progressBar);
-
-    // Append the progress container to the document body or any other desired parent element
     document.body.appendChild(progressContainer);
   }
   createProgressBar();
 
-  /** Update the progress bar
-   *  when user scrolls */
   function updateScrollProgress() {
     document.addEventListener("scroll", () => {
       const winScroll =
@@ -282,8 +321,6 @@ const frontmatterPreview = [
   }
   updateScrollProgress();
 
-  /** Attaches links to headings in the document,
-   *  allowing sharing of sections easily */
   function addHeadingLinks() {
     const headings = Array.from(
       document.querySelectorAll("h2, h3, h4, h5, h6")
@@ -304,8 +341,6 @@ const frontmatterPreview = [
   }
   addHeadingLinks();
 
-  /** Attaches copy buttons to code blocks in the document,
-   * allowing users to copy code easily. */
   function attachCopyButtons() {
     const copyButtonLabel = "Copy";
     const codeBlocks = Array.from(document.querySelectorAll("pre"));
@@ -314,12 +349,9 @@ const frontmatterPreview = [
       const wrapper = document.createElement("div");
       wrapper.style.position = "relative";
 
-      // Check if --file-name-offset custom property exists
       const computedStyle = getComputedStyle(codeBlock);
       const hasFileNameOffset =
         computedStyle.getPropertyValue("--file-name-offset").trim() !== "";
-
-      // Determine the top positioning class
       const topClass = hasFileNameOffset
         ? "top-(--file-name-offset)"
         : "-top-3";
@@ -330,7 +362,6 @@ const frontmatterPreview = [
       codeBlock.setAttribute("tabindex", "0");
       codeBlock.appendChild(copyButton);
 
-      // wrap codebock with relative parent element
       codeBlock?.parentNode?.insertBefore(wrapper, codeBlock);
       wrapper.appendChild(codeBlock);
 
@@ -344,8 +375,6 @@ const frontmatterPreview = [
       const text = code?.innerText;
 
       await navigator.clipboard.writeText(text ?? "");
-
-      // visual feedback that task is completed
       button.innerText = "Copied";
 
       setTimeout(() => {
@@ -355,7 +384,6 @@ const frontmatterPreview = [
   }
   attachCopyButtons();
 
-  /* Go to page start after page swap */
   document.addEventListener("astro:after-swap", () =>
     window.scrollTo({ left: 0, top: 0, behavior: "instant" })
   );

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -4,115 +4,162 @@ title: "About"
 description: "Matt Berryhill builds AI-native operating systems, agent workflows, and discovery surfaces that make autonomous work easier to inspect, trust, and improve."
 ---
 
-<div class="about-hero">
-  <div class="about-intro about-terminal terminal-shell">
-    <p class="terminal-path">cat ~/berryhill.dev/about.md</p>
-    <p class="intro-text">
-      <span class="drop-cap">M</span>att Berryhill builds AI-native operating systems: agent workflows, discovery surfaces, review loops, and the governance layer that turns intelligent automation into work people can inspect and trust.
-    </p>
+<div class="terminal-shell about-terminal-hero">
+  <div class="terminal-chrome" aria-hidden="true">
+    <span class="terminal-dots">
+      <span class="terminal-dot"></span>
+      <span class="terminal-dot"></span>
+      <span class="terminal-dot"></span>
+    </span>
+    <span>matt@berryhill: ~/berryhill.dev/about.md</span>
+    <span>truthful profile</span>
   </div>
-
-  <div class="about-image">
-    <div class="image-fade-container">
-      <img src="/matt_headshot.jpeg" alt="Matt Berryhill" class="headshot" loading="eager" />
-      <img src="/avatar.png" alt="Matt Berryhill Avatar" class="avatar" loading="eager" />
+  <div class="terminal-body">
+    <p class="terminal-path">cat about.md</p>
+    <h1>I build AI-native systems that make autonomous work easier to inspect, trust, and improve.</h1>
+    <p class="about-deck">
+      Matt Berryhill builds AI-native operating systems: agent workflows, discovery surfaces, review loops, and the governance layer that turns intelligent automation into work people can inspect and trust.
+    </p>
+    <p class="about-deck">
+      I write and build around the layer most AI demos skip: context, ownership, evidence, memory, review, and the human judgment required to turn a promising agent loop into reliable work.
+    </p>
+    <div class="about-portrait" aria-label="Matt Berryhill portrait assets">
+      <img src="/matt_headshot.jpeg" alt="Matt Berryhill" loading="eager" />
+      <img src="/avatar.png" alt="Matt Berryhill avatar" loading="lazy" />
+    </div>
+    <div class="terminal-grid cols-3 about-summary" aria-label="Profile summary">
+      <div class="terminal-stat">
+        <strong>AI-native</strong>
+        <span>systems</span>
+      </div>
+      <div class="terminal-stat">
+        <strong>agentic</strong>
+        <span>workflows</span>
+      </div>
+      <div class="terminal-stat">
+        <strong>public</strong>
+        <span>operating notes</span>
+      </div>
     </div>
   </div>
 </div>
 
+<div class="about-grid">
+  <aside class="terminal-panel about-toc">
+    <p class="terminal-command">grep -n "^##" about.md</p>
+    <ol>
+      <li><a href="#what-im-building">What I’m building</a></li>
+      <li><a href="#current-focus">Current focus</a></li>
+      <li><a href="#what-i-believe">What I believe</a></li>
+      <li><a href="#how-to-read-this-site">How to read this site</a></li>
+      <li><a href="#contact">Contact</a></li>
+    </ol>
+  </aside>
+
+  <div class="about-body">
+
 ## What I’m building
 
 This site is not a normal archive. It is the public surface of an operating system for AI-native work: posts, field notes, diagrams, and experiments that show how agents are actually used, where they break, and what has to exist around them for the work to compound.
+
+The long-term direction is a discovery system: domain watches, evidence snapshots, claims, updates, diagrams, essays, reports, and machine-readable surfaces that let humans and agents understand what changed and why it matters.
 
 ## Current focus
 
 - Agentic development loops that close faster and verify better.
 - Discovery systems that preserve claims, evidence, updates, and context.
 - Governance patterns for handoffs, ownership, escalation, and review.
+- AI-native publishing systems where posts, reports, and future books can come from the same living knowledge base.
 - Public writing that turns real build work into reusable operating models.
+
+## What I believe
+
+Agents do not remove the need for operators. They move the operator’s job up a level.
+
+The valuable work is no longer just writing the first draft, producing the first patch, or finding the first source. The valuable work is knowing what counts as evidence, what should be preserved, what should be thrown away, when a system has drifted, and when a human needs to take responsibility.
+
+That is the operating layer this site is trying to make visible.
 
 ## How to read this site
 
 Start with the posts if you want the public arguments. Follow the field notes if you want the operating lessons. Treat the diagrams and metadata as part of the artifact: they are there to make the work easier to inspect, cite, and revisit.
 
+This is also why the site is terminal-inspired. The shell is not decoration. It is a reminder that the public surface should feel like an interface into a working system, not a brochure about one.
+
+## Contact
+
 If you want to talk about AI-native products, agent operations, governance, discovery systems, or the gap between a promising demo and a reliable workflow, <a href="https://calendly.com/matt-berryhill/30min" target="_blank" rel="noopener noreferrer">schedule a call</a>.
 
+  </div>
+</div>
+
 <style>
-  .about-hero {
-    display: grid;
-    grid-template-columns: 1fr 300px;
-    gap: 3rem;
-    align-items: start;
-    margin-bottom: 3rem;
+  .about-terminal-hero {
+    margin-bottom: 1.5rem;
   }
 
-  .about-terminal {
-    padding: 1.25rem;
-  }
-
-  @media (max-width: 768px) {
-    .about-hero {
-      grid-template-columns: 1fr;
-      gap: 2rem;
-    }
-
-    .about-image {
-      order: -1;
-    }
-  }
-
-  .intro-text {
+  .about-deck {
+    max-width: 58rem;
     margin-top: 1rem;
-    font-size: 1.125rem;
-    line-height: 1.75;
     color: var(--fg-secondary);
+    font-size: clamp(1.05rem, 1rem + 0.25vw, 1.25rem);
+    line-height: 1.75;
   }
 
-  .drop-cap {
-    float: left;
-    font-size: 3.5rem;
-    line-height: 1;
-    font-weight: 700;
-    margin-right: 0.125rem;
-    margin-top: -0.1rem;
-    color: var(--foreground);
+  .about-portrait {
+    display: flex;
+    gap: 0.75rem;
+    margin-top: 1.25rem;
   }
 
-  .image-fade-container {
-    position: relative;
-    width: 300px;
-    height: 300px;
-    margin: 0 auto;
-    cursor: pointer;
-  }
-
-  .image-fade-container img {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+  .about-portrait img {
+    width: 4rem;
+    height: 4rem;
+    border: 1px solid var(--terminal-border);
+    border-radius: 999px;
     object-fit: cover;
-    border-radius: 50%;
-    transition: opacity 0.5s ease-in-out;
-    border: 3px solid var(--border);
   }
 
-  .headshot {
-    opacity: 1;
-    z-index: 2;
+  .about-summary {
+    margin-top: 1.25rem;
   }
 
-  .avatar {
-    opacity: 0;
-    z-index: 1;
+  .about-grid {
+    display: grid;
+    gap: 1.25rem;
+    margin-top: 1.25rem;
   }
 
-  .image-fade-container:hover .headshot {
-    opacity: 0;
+  @media (min-width: 960px) {
+    .about-grid {
+      grid-template-columns: 17rem minmax(0, 1fr);
+      align-items: start;
+    }
   }
 
-  .image-fade-container:hover .avatar {
-    opacity: 1;
+  .about-toc {
+    padding: 1rem;
+  }
+
+  @media (min-width: 960px) {
+    .about-toc {
+      position: sticky;
+      top: 6rem;
+    }
+  }
+
+  .about-toc ol {
+    margin: 1rem 0 0;
+    padding-left: 1.2rem;
+  }
+
+  .about-toc li {
+    margin: 0.45rem 0;
+    color: var(--terminal-muted);
+    font-size: 0.92rem;
+  }
+
+  .about-body {
+    min-width: 0;
   }
 </style>

--- a/src/pages/about.md
+++ b/src/pages/about.md
@@ -1,13 +1,14 @@
 ---
 layout: ../layouts/AboutLayout.astro
 title: "About"
-description: "Matt Berryhill is an agentic-first builder focused on AI-native systems, agent workflows, governance, provenance, and the operating discipline required to turn intelligent automation into shipped work."
+description: "Matt Berryhill builds AI-native operating systems, agent workflows, and discovery surfaces that make autonomous work easier to inspect, trust, and improve."
 ---
 
 <div class="about-hero">
-  <div class="about-intro">
+  <div class="about-intro about-terminal terminal-shell">
+    <p class="terminal-path">cat ~/berryhill.dev/about.md</p>
     <p class="intro-text">
-      <span class="drop-cap">M</span>att Berryhill is an agentic-first builder focused on the operating layer of AI-native systems.
+      <span class="drop-cap">M</span>att Berryhill builds AI-native operating systems: agent workflows, discovery surfaces, review loops, and the governance layer that turns intelligent automation into work people can inspect and trust.
     </p>
   </div>
 
@@ -19,13 +20,20 @@ description: "Matt Berryhill is an agentic-first builder focused on AI-native sy
   </div>
 </div>
 
-## The Work
+## What I’m building
 
-He works where intelligent products, agent workflows, governance, and technical culture meet: the place where ideas stop being demos and start becoming systems people can review, trust, and ship.
+This site is not a normal archive. It is the public surface of an operating system for AI-native work: posts, field notes, diagrams, and experiments that show how agents are actually used, where they break, and what has to exist around them for the work to compound.
 
-Berryhill.dev is where Matt writes through that work in public. The through-line is not that every tool is new. The through-line is that agentic systems need operating discipline: authority, provenance, review, handoffs, memory, escalation, and proof that the work actually landed.
+## Current focus
 
-Matt thinks about products and teams as living systems. Skill matters, but mindset matters more: hunger, curiosity, consistency, and the ability to notice where the workflow is lying to you. The best teams balance autonomy with alignment, reward outcomes over optics, and make progress visible enough to inspect.
+- Agentic development loops that close faster and verify better.
+- Discovery systems that preserve claims, evidence, updates, and context.
+- Governance patterns for handoffs, ownership, escalation, and review.
+- Public writing that turns real build work into reusable operating models.
+
+## How to read this site
+
+Start with the posts if you want the public arguments. Follow the field notes if you want the operating lessons. Treat the diagrams and metadata as part of the artifact: they are there to make the work easier to inspect, cite, and revisit.
 
 If you want to talk about AI-native products, agent operations, governance, discovery systems, or the gap between a promising demo and a reliable workflow, <a href="https://calendly.com/matt-berryhill/30min" target="_blank" rel="noopener noreferrer">schedule a call</a>.
 
@@ -36,6 +44,10 @@ If you want to talk about AI-native products, agent operations, governance, disc
     gap: 3rem;
     align-items: start;
     margin-bottom: 3rem;
+  }
+
+  .about-terminal {
+    padding: 1.25rem;
   }
 
   @media (max-width: 768px) {
@@ -50,6 +62,7 @@ If you want to talk about AI-native products, agent operations, governance, disc
   }
 
   .intro-text {
+    margin-top: 1rem;
     font-size: 1.125rem;
     line-height: 1.75;
     color: var(--fg-secondary);

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,13 +6,10 @@ import Layout from "@/layouts/Layout.astro";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
 import Socials from "@/components/Socials.astro";
-import LinkButton from "@/components/LinkButton.astro";
 import Card from "@/components/Card.astro";
-import Hr from "@/components/Hr.astro";
 import PillarModal from "@/components/PillarModal.astro";
 import getSortedPosts from "@/utils/getSortedPosts";
 import IconRss from "@/assets/icons/IconRss.svg";
-import IconArrowRight from "@/assets/icons/IconArrowRight.svg";
 import { SITE } from "@/config";
 import { SOCIALS } from "@/constants";
 import { buildWebSiteJsonLd } from "@/utils/structuredData";
@@ -22,6 +19,18 @@ const { entries: posts } = await getLiveCollection("liveBlog");
 const sortedPosts = getSortedPosts(posts || []);
 const featuredPosts = sortedPosts.filter(({ data }) => data.featured);
 const recentPosts = sortedPosts.filter(({ data }) => !data.featured);
+const visibleRecentPosts = recentPosts.slice(0, SITE.postPerIndex);
+const totalWords = sortedPosts.reduce(
+  (sum, post) =>
+    sum + (post.body || "").trim().split(/\s+/).filter(Boolean).length,
+  0
+);
+const tagCount = new Set(sortedPosts.flatMap(({ data }) => data.tags ?? []))
+  .size;
+const lastPostDate = sortedPosts[0]?.data?.pubDatetime;
+const lastPostLabel = lastPostDate
+  ? new Date(lastPostDate).toISOString().slice(0, 10)
+  : "pending";
 const jsonLd = buildWebSiteJsonLd({
   name: SITE.title,
   url: SITE.website,
@@ -38,448 +47,235 @@ const jsonLd = buildWebSiteJsonLd({
   <main
     id="main-content"
     data-layout="index"
-    class="mx-auto max-w-6xl px-4 sm:px-6"
+    class="terminal-page px-4 pb-16 sm:px-6"
   >
-    <!-- Hero Section -->
-    <section id="hero" class="relative max-w-5xl pt-8 pb-6">
-      <div class="hero-content terminal-shell relative p-4 md:p-6">
-        <p class="terminal-path text-sm md:text-base">whoami</p>
-        <h1
-          id="home-terminal-title"
-          class="mt-3 mb-4 text-3xl leading-tight font-bold tracking-tight md:text-5xl"
-        >
-          Matt Berryhill builds AI-native operating systems in public.
-        </h1>
+    <section id="hero" class="pt-8 pb-6" aria-labelledby="home-terminal-title">
+      <div class="terminal-shell">
+        <div class="terminal-chrome" aria-hidden="true">
+          <span class="terminal-dots">
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+          </span>
+          <span>matt@berryhill: ~/berryhill.dev</span>
+          <span>human-led</span>
+        </div>
 
-        <div class="mb-4 space-y-3">
-          <p class="text-skin-base max-w-3xl text-base leading-8 md:text-lg">
+        <div class="terminal-body">
+          <p class="terminal-path text-sm md:text-base">whoami --verbose</p>
+          <h1
+            id="home-terminal-title"
+            class="mt-4 max-w-4xl text-4xl leading-tight font-bold tracking-tight md:text-6xl"
+          >
+            Matt Berryhill builds AI-native operating systems in public.
+          </h1>
+          <p
+            class="text-skin-base mt-5 max-w-3xl text-base leading-8 md:text-lg"
+          >
             Berryhill.dev is the public surface for agent workflows, discovery
             systems, governance, provenance, and the operator judgment required
-            to turn AI output into shipped proof.
+            to turn AI output into shipped proof. The new shell makes that
+            surface feel like a working terminal, not a brochure.
           </p>
-          <div class="operator-read max-w-3xl">
-            <p
-              class="text-skin-muted font-mono text-xs tracking-widest uppercase"
-            >
-              operator read
-            </p>
+
+          <div class="mt-6 grid gap-3 md:grid-cols-3" aria-label="Site state">
+            <div class="terminal-stat">
+              <strong>{sortedPosts.length}</strong>
+              <span>published artifacts</span>
+            </div>
+            <div class="terminal-stat">
+              <strong>{tagCount}</strong>
+              <span>public lanes</span>
+            </div>
+            <div class="terminal-stat">
+              <strong>{lastPostLabel}</strong>
+              <span>latest post</span>
+            </div>
+          </div>
+
+          <div class="operator-read mt-6 max-w-3xl">
+            <p class="terminal-kicker">operator read</p>
             <p class="text-skin-base mt-2 text-sm leading-7">
               The useful question is not whether agents can produce more output.
               It is whether the system can preserve context, ownership,
               verification, and memory long enough for the work to compound.
             </p>
           </div>
-          <p class="text-skin-muted text-sm leading-relaxed md:text-base">
+
+          <div class="mt-6 flex flex-wrap items-center gap-3 text-sm">
+            <a
+              target="_blank"
+              href="/rss.xml"
+              class="inline-flex items-center gap-1.5"
+              aria-label="rss feed"
+            >
+              <IconRss width={16} height={16} />
+              <span>rss.xml</span>
+            </a>
+            {
+              SOCIALS.length > 0 && (
+                <>
+                  <span class="text-skin-muted">|</span>
+                  <Socials />
+                </>
+              )
+            }
+            <span class="terminal-safe-note"
+              >Terminal metaphor. Real claims only.</span
+            >
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="system-map" class="py-4" aria-labelledby="system-map-title">
+      <div class="terminal-grid cols-2">
+        <div class="terminal-panel p-4 md:p-5">
+          <p class="terminal-command text-sm">cat manifesto.md</p>
+          <h2 id="system-map-title" class="mt-3 text-2xl font-semibold">
+            Not a nicer blog. A public interface into the operating layer.
+          </h2>
+          <p class="text-skin-muted mt-3 text-sm leading-7 md:text-base">
             Most AI content stops at tools, prompts, and demos. The harder
             problem is building systems that know who owns the work, what
             evidence was used, what changed, what shipped, and where a human
-            must stay in the loop. This site tracks that layer: workflows,
-            protocols, review gates, and operating habits that make agentic
-            systems useful outside the demo.
+            must stay in the loop.
           </p>
         </div>
 
-        <!-- RSS Feed and Social Links -->
-        <div class="link-container flex flex-wrap items-center gap-3 text-sm">
-          <a
-            target="_blank"
-            href="/rss.xml"
-            class="link-hover inline-flex items-center gap-1.5"
-            aria-label="rss feed"
-          >
-            <IconRss width={16} height={16} />
-            <span>RSS Feed</span>
-          </a>
-          {
-            SOCIALS.length > 0 && (
-              <>
-                <span class="text-skin-muted">|</span>
-                <div class="flex items-center gap-2">
-                  <span class="text-skin-muted">Follow:</span>
-                  <Socials />
-                </div>
-              </>
-            )
-          }
-        </div>
-      </div>
-    </section>
-
-    <section
-      id="field-notes-terminal"
-      class="section-animate py-4"
-      aria-labelledby="field-notes-terminal-title"
-    >
-      <div class="terminal-interface rounded-2xl border p-4 md:p-5">
-        <div class="mb-4 flex flex-wrap items-start justify-between gap-3">
-          <div>
-            <p
-              id="field-notes-terminal-title"
-              class="terminal-prompt font-mono text-sm md:text-base"
-            >
-              berryhill.dev / operating-surface
-            </p>
-            <p
-              class="terminal-status mt-2 text-sm leading-relaxed md:text-base"
-            >
-              Public notes on AI-native systems, agent governance, provenance,
-              and shipped proof: the public operating surface for the work.
-            </p>
-          </div>
-          <p class="safety-label rounded-full px-3 py-1 font-mono text-xs">
-            Terminal metaphor. Real claims only.
-          </p>
-        </div>
-
-        <ul class="terminal-command-list grid list-none gap-2 md:grid-cols-2">
-          <li>
-            <button
-              type="button"
-              class="cycle-word pillar-clickable terminal-command"
-              data-pillar="governance"
-            >
-              open governance checklist
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              class="cycle-word pillar-clickable terminal-command"
-              data-pillar="proof"
-            >
-              inspect shipped-work proof
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              class="cycle-word pillar-clickable terminal-command"
-              data-pillar="protocol"
-            >
-              trace protocol boundaries
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              class="cycle-word pillar-clickable terminal-command"
-              data-pillar="continuity"
-            >
-              read continuity layer notes
-            </button>
-          </li>
-          <li>
-            <button
-              type="button"
-              class="cycle-word pillar-clickable terminal-command"
-              data-pillar="conversation"
-            >
-              schedule operator conversation
-            </button>
-          </li>
-        </ul>
-      </div>
-    </section>
-
-    <style>
-      .terminal-interface {
-        border-color: color-mix(in srgb, var(--accent) 35%, transparent);
-        background: color-mix(in srgb, var(--background) 92%, var(--accent));
-        box-shadow: 0 18px 45px rgba(0, 0, 0, 0.16);
-      }
-
-      .terminal-prompt {
-        color: var(--accent);
-        font-weight: 700;
-        text-shadow: 0 0 10px rgba(59, 130, 246, 0.3);
-      }
-
-      .terminal-status {
-        color: var(--foreground);
-      }
-
-      .safety-label {
-        border: 1px solid color-mix(in srgb, var(--accent) 35%, transparent);
-        color: var(--foreground-muted);
-        background: rgba(0, 0, 0, 0.08);
-      }
-
-      .terminal-command-list {
-        margin: 0;
-        padding: 0;
-      }
-
-      .terminal-command {
-        width: 100%;
-        border: 1px solid color-mix(in srgb, var(--accent) 22%, transparent);
-        border-radius: 0.75rem;
-        padding: 0.75rem 0.9rem;
-        background: rgba(0, 0, 0, 0.08);
-        color: var(--foreground);
-        font-family: "Courier New", monospace;
-        font-size: 0.95rem;
-        line-height: 1.4;
-        text-align: left;
-      }
-
-      .terminal-command::before {
-        content: "$ ";
-        color: var(--accent);
-        font-weight: 700;
-      }
-
-      .terminal-command:focus-visible {
-        outline: 2px solid var(--accent);
-        outline-offset: 3px;
-      }
-
-      .cycle-word {
-        color: var(--foreground);
-        position: relative;
-        transition: all 0.3s ease;
-      }
-
-      .highlight-word {
-        color: #d91c5c !important;
-        font-weight: 700;
-      }
-
-      .cycle-word:hover {
-        color: var(--accent);
-        transform: translateY(-2px);
-      }
-
-      .cycle-word.pillar-clickable {
-        cursor: pointer;
-        user-select: none;
-      }
-
-      .cycle-word.pillar-clickable:hover {
-        text-decoration: underline;
-        text-underline-offset: 4px;
-      }
-
-      .cycle-word.highlight {
-        color: #d91c5c !important;
-        font-weight: 700;
-      }
-
-      .arrow {
-        color: var(--foreground-muted);
-        opacity: 0.4;
-        font-size: 0.9em;
-      }
-
-      .cursor-blink {
-        color: var(--accent);
-        animation: blink 1s step-end infinite;
-        font-weight: 700;
-      }
-
-      @keyframes blink {
-        0%,
-        50% {
-          opacity: 1;
-        }
-        51%,
-        100% {
-          opacity: 0;
-        }
-      }
-
-      .link-hover {
-        color: var(--accent);
-        transition: all 0.2s ease;
-        position: relative;
-      }
-
-      .link-hover::after {
-        content: "";
-        position: absolute;
-        bottom: -2px;
-        left: 0;
-        width: 0;
-        height: 2px;
-        background: var(--accent);
-        transition: width 0.3s ease;
-      }
-
-      .link-hover:hover::after {
-        width: 100%;
-      }
-
-      .link-hover:hover {
-        transform: translateX(2px);
-      }
-
-      .hero-content {
-        animation: fadeInUp 0.6s ease-out;
-      }
-
-      @keyframes fadeInUp {
-        from {
-          opacity: 0;
-          transform: translateY(20px);
-        }
-        to {
-          opacity: 1;
-          transform: translateY(0);
-        }
-      }
-    </style>
-
-    <Hr />
-
-    {
-      sortedPosts.length > 0 && (
-        <section id="start-here" class="section-animate pt-4 pb-2">
-          <p class="text-skin-muted max-w-3xl text-sm leading-relaxed md:text-base">
+        <div class="terminal-panel p-4 md:p-5">
+          <p class="terminal-command text-sm">ls operating-layer/</p>
+          <p class="text-skin-muted mt-3 text-sm leading-7">
             Start with the operating layer: agent governance, shipped-work
             proof, protocol boundaries, discovery systems, continuity, and the
             public operating models that keep AI work accountable.
           </p>
+          <ul
+            class="mt-4 grid list-none gap-2 p-0 text-sm leading-6 md:text-base"
+          >
+            <li>
+              <button
+                type="button"
+                class="cycle-word pillar-clickable terminal-command"
+                data-pillar="governance"
+              >
+                open governance checklist
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="cycle-word pillar-clickable terminal-command"
+                data-pillar="proof"
+              >
+                inspect shipped-work proof
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="cycle-word pillar-clickable terminal-command"
+                data-pillar="protocol"
+              >
+                trace protocol boundaries
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="cycle-word pillar-clickable terminal-command"
+                data-pillar="continuity"
+              >
+                read continuity layer notes
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                class="cycle-word pillar-clickable terminal-command"
+                data-pillar="conversation"
+              >
+                schedule operator conversation
+              </button>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    {
+      featuredPosts.length > 0 && (
+        <section id="featured" class="py-6" aria-labelledby="featured-title">
+          <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p class="terminal-command text-sm">cat featured.md</p>
+              <h2 id="featured-title" class="mt-2 text-2xl font-bold">
+                Author-picked artifacts
+              </h2>
+            </div>
+            <p class="text-skin-muted max-w-lg text-sm leading-6">
+              Featured means editorially selected by Matt/Luca, not popularity
+              metrics or fake social proof.
+            </p>
+          </div>
+
+          <ul class="grid list-none grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
+            {featuredPosts.map(data => (
+              <Card variant="h2" {...data} />
+            ))}
+          </ul>
         </section>
       )
     }
 
     {
-      featuredPosts.length > 0 && (
-        <>
-          <section id="featured" class="section-animate pt-4 pb-4">
-            <h2 class="text-skin-accent mb-4 text-xl font-bold">
-              Featured Posts
-            </h2>
-
-            <ul class="grid list-none grid-cols-1 gap-4 md:grid-cols-2 md:gap-6">
-              {featuredPosts.map(data => (
-                <Card variant="h2" {...data} />
-              ))}
-            </ul>
-          </section>
-          <Hr />
-        </>
-      )
-    }
-
-    {
       recentPosts.length > 0 && (
-        <>
-          <section id="recent-posts" class="section-animate pt-4 pb-4">
-            <h2 class="text-skin-accent mb-4 text-xl font-bold">
-              Recent Posts
-            </h2>
+        <section id="recent-posts" class="py-6" aria-labelledby="recent-title">
+          <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+            <div>
+              <p class="terminal-command text-sm">ls -la recent/</p>
+              <h2 id="recent-title" class="mt-2 text-2xl font-bold">
+                Recent field notes
+              </h2>
+            </div>
+            <p class="text-skin-muted font-mono text-sm">
+              {totalWords.toLocaleString()} real words indexed
+            </p>
+          </div>
 
-            <ul class="grid list-none grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {recentPosts.map(
-                (data, index) =>
-                  index < SITE.postPerIndex && <Card variant="h3" {...data} />
-              )}
-            </ul>
-          </section>
-        </>
+          <ul class="grid list-none grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {visibleRecentPosts.map(data => (
+              <Card variant="h3" {...data} />
+            ))}
+          </ul>
+        </section>
       )
     }
 
-    <style>
-      .section-animate {
-        animation: slideInUp 0.5s ease-out;
-      }
-
-      @keyframes slideInUp {
-        from {
-          opacity: 0;
-          transform: translateY(30px);
-        }
-        to {
-          opacity: 1;
-          transform: translateY(0);
-        }
-      }
-
-      .section-header-fancy {
-        margin-bottom: 1.5rem;
-      }
-
-      .gradient-title {
-        background: linear-gradient(
-          135deg,
-          var(--accent) 0%,
-          var(--foreground) 50%,
-          var(--accent) 100%
-        );
-        background-size: 200% auto;
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-        background-clip: text;
-        animation: shimmer 3s linear infinite;
-        position: relative;
-        padding-bottom: 0.5rem;
-      }
-
-      .gradient-title::after {
-        content: "";
-        position: absolute;
-        bottom: 0;
-        left: 0;
-        width: 100%;
-        height: 2px;
-        background: linear-gradient(90deg, var(--accent), transparent);
-        animation: expandWidth 1s ease-out;
-      }
-
-      .title-glow {
-        position: absolute;
-        top: 50%;
-        left: 50%;
-        transform: translate(-50%, -50%);
-        width: 120%;
-        height: 120%;
-        background: radial-gradient(circle, var(--accent) 0%, transparent 70%);
-        opacity: 0.15;
-        filter: blur(20px);
-        z-index: -1;
-        animation: pulse 2s ease-in-out infinite;
-      }
-
-      @keyframes shimmer {
-        0% {
-          background-position: 0% center;
-        }
-        100% {
-          background-position: 200% center;
-        }
-      }
-
-      @keyframes expandWidth {
-        from {
-          width: 0%;
-        }
-        to {
-          width: 100%;
-        }
-      }
-
-      @keyframes pulse {
-        0%,
-        100% {
-          opacity: 0.15;
-          transform: translate(-50%, -50%) scale(1);
-        }
-        50% {
-          opacity: 0.25;
-          transform: translate(-50%, -50%) scale(1.1);
-        }
-      }
-    </style>
-
-    <!-- View All Posts CTA -->
-    <div class="my-12 text-center">
-      <LinkButton href="/posts/" class="px-8 py-3 text-lg">
-        Read the field notes, then bring the operating questions to a
+    <section
+      class="terminal-panel my-8 p-4 md:p-5"
+      aria-labelledby="contact-title"
+    >
+      <p class="terminal-command text-sm">cat .env</p>
+      <h2 id="contact-title" class="mt-2 text-2xl font-bold">
+        Bring the operating questions.
+      </h2>
+      <p class="text-skin-muted mt-3 max-w-3xl text-sm leading-7 md:text-base">
+        If you want to talk about AI-native products, agent operations,
+        governance, discovery systems, or the gap between a promising demo and a
+        reliable workflow, start with the posts and then schedule a
         conversation.
-        <IconArrowRight class="ml-2 inline-block rtl:-rotate-180" />
-      </LinkButton>
-    </div>
+      </p>
+      <div class="mt-4 flex flex-wrap gap-3 font-mono text-sm">
+        <a href="/posts/">POSTS=/posts/</a>
+        <a href="/about/">ABOUT=/about/</a>
+        <a
+          href="https://calendly.com/matt-berryhill/30min"
+          target="_blank"
+          rel="noopener noreferrer">CAL=/30min</a
+        >
+      </div>
+    </section>
   </main>
   <Footer />
   <PillarModal />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -41,25 +41,39 @@ const jsonLd = buildWebSiteJsonLd({
     class="mx-auto max-w-6xl px-4 sm:px-6"
   >
     <!-- Hero Section -->
-    <section id="hero" class="relative max-w-4xl pt-8 pb-4">
-      <div class="hero-content relative">
+    <section id="hero" class="relative max-w-5xl pt-8 pb-6">
+      <div class="hero-content terminal-shell relative p-4 md:p-6">
+        <p class="terminal-path text-sm md:text-base">whoami</p>
         <h1
-          class="mb-4 text-3xl leading-tight font-bold tracking-tight md:text-5xl"
+          id="home-terminal-title"
+          class="mt-3 mb-4 text-3xl leading-tight font-bold tracking-tight md:text-5xl"
         >
-          Matt Berryhill builds AI-native discovery systems.
+          Matt Berryhill builds AI-native operating systems in public.
         </h1>
 
-        <div class="mb-4 space-y-2">
-          <p class="text-skin-base text-base leading-relaxed md:text-lg">
-            Berryhill.dev is his public field notebook on agentic workflows,
-            governance, provenance, and the operator judgment required to turn
-            AI work into shipped proof.
+        <div class="mb-4 space-y-3">
+          <p class="text-skin-base max-w-3xl text-base leading-8 md:text-lg">
+            Berryhill.dev is the public surface for agent workflows, discovery
+            systems, governance, provenance, and the operator judgment required
+            to turn AI output into shipped proof.
           </p>
+          <div class="operator-read max-w-3xl">
+            <p
+              class="text-skin-muted font-mono text-xs tracking-widest uppercase"
+            >
+              operator read
+            </p>
+            <p class="text-skin-base mt-2 text-sm leading-7">
+              The useful question is not whether agents can produce more output.
+              It is whether the system can preserve context, ownership,
+              verification, and memory long enough for the work to compound.
+            </p>
+          </div>
           <p class="text-skin-muted text-sm leading-relaxed md:text-base">
             Most AI content stops at tools, prompts, and demos. The harder
             problem is building systems that know who owns the work, what
             evidence was used, what changed, what shipped, and where a human
-            must stay in the loop. This site tracks that layer: the workflows,
+            must stay in the loop. This site tracks that layer: workflows,
             protocols, review gates, and operating habits that make agentic
             systems useful outside the demo.
           </p>
@@ -103,17 +117,17 @@ const jsonLd = buildWebSiteJsonLd({
               id="field-notes-terminal-title"
               class="terminal-prompt font-mono text-sm md:text-base"
             >
-              berryhill.dev / field-notes
+              berryhill.dev / operating-surface
             </p>
             <p
               class="terminal-status mt-2 text-sm leading-relaxed md:text-base"
             >
               Public notes on AI-native systems, agent governance, provenance,
-              and shipped proof.
+              and shipped proof: the public operating surface for the work.
             </p>
           </div>
           <p class="safety-label rounded-full px-3 py-1 font-mono text-xs">
-            Interface metaphor, not live telemetry.
+            Terminal metaphor. Real claims only.
           </p>
         </div>
 
@@ -321,8 +335,8 @@ const jsonLd = buildWebSiteJsonLd({
         <section id="start-here" class="section-animate pt-4 pb-2">
           <p class="text-skin-muted max-w-3xl text-sm leading-relaxed md:text-base">
             Start with the operating layer: agent governance, shipped-work
-            proof, protocol boundaries, small named fleets, continuity, and the
-            systems that keep AI work accountable.
+            proof, protocol boundaries, discovery systems, continuity, and the
+            public operating models that keep AI work accountable.
           </p>
         </section>
       )

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -32,10 +32,9 @@ const totalPages = Math.ceil(sortedPosts.length / pageSize);
 const start = (currentPage - 1) * pageSize;
 const end = start + pageSize;
 const paginatedPosts = sortedPosts.slice(start, end);
-const postsDeck =
-  "Field notes on agentic systems, governance, protocols, provenance, IP intelligence, continuity, and the operator work that turns AI output into shipped proof.";
+const postsDeck = "Posts as artifacts from the operating system.";
 const postsIntro =
-  "Read these as a developing operating manual. Some pieces are tactical checklists. Some are system maps. Some are arguments about where AI-native work is actually bottlenecked: not in model access, but in authority, review, memory, handoffs, and accountability.";
+  "Read these as a developing operating manual: agent governance, discovery systems, protocol boundaries, verification loops, and the human decisions that keep autonomous work accountable.";
 const postsMetadataDescription =
   "Essays and field notes from Matt Berryhill on agent governance, AI-native workflows, protocol boundaries, continuity layers, IP intelligence, and shipped-work proof.";
 
@@ -70,9 +69,41 @@ const jsonLd = buildCollectionPageJsonLd({
 >
   <Header />
   <Main pageTitle="Posts" pageDesc={postsDeck}>
-    <p class="text-skin-base mb-8 max-w-3xl text-lg leading-8">
-      {postsIntro}
-    </p>
+    <section
+      class="terminal-shell mb-8 p-4 md:p-5"
+      aria-labelledby="posts-terminal-title"
+    >
+      <p class="terminal-path text-sm md:text-base">
+        ls ~/berryhill.dev/posts --group-by lane
+      </p>
+      <h2 id="posts-terminal-title" class="mt-3 text-2xl font-semibold">
+        Essays, field notes, and system maps from AI-native work.
+      </h2>
+      <p class="text-skin-base mt-3 max-w-3xl text-base leading-8">
+        {postsIntro}
+      </p>
+      <ul
+        class="mt-4 grid gap-2 text-sm md:grid-cols-2"
+        aria-label="Primary lanes"
+      >
+        <li>
+          <span class="text-skin-accent font-mono">agents/</span> workflows, handoffs,
+          review
+        </li>
+        <li>
+          <span class="text-skin-accent font-mono">discovery/</span> claims, evidence,
+          continuity
+        </li>
+        <li>
+          <span class="text-skin-accent font-mono">systems/</span> protocols, governance,
+          provenance
+        </li>
+        <li>
+          <span class="text-skin-accent font-mono">field-notes/</span>
+          practical operator lessons
+        </li>
+      </ul>
+    </section>
     <ul class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
       {page.data.map(data => <Card variant="h3" {...data} />)}
     </ul>

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -2,7 +2,6 @@
 export const prerender = false;
 
 import { getLiveCollection } from "astro:content";
-import Main from "@/layouts/Main.astro";
 import Layout from "@/layouts/Layout.astro";
 import Header from "@/components/Header.astro";
 import Footer from "@/components/Footer.astro";
@@ -14,11 +13,8 @@ import { buildCollectionPageJsonLd } from "@/utils/structuredData";
 
 const { page: pageParam } = Astro.params;
 
-// This route handles /posts/[number] - validate it's actually a number
 const currentPage = parseInt(pageParam);
 if (isNaN(currentPage) || !pageParam.match(/^\d+$/)) {
-  // Not a valid page number, this must be a post slug
-  // Return 404 so the [...slug] route can handle it
   return new Response(null, { status: 404 });
 }
 
@@ -26,19 +22,34 @@ const { entries: allPosts } = await getLiveCollection("liveBlog");
 const posts = (allPosts || []).filter(({ data }) => !data.draft);
 const sortedPosts = getSortedPosts(posts);
 
-// Calculate pagination
 const pageSize = SITE.postPerPage;
 const totalPages = Math.ceil(sortedPosts.length / pageSize);
 const start = (currentPage - 1) * pageSize;
 const end = start + pageSize;
 const paginatedPosts = sortedPosts.slice(start, end);
+const totalWords = sortedPosts.reduce(
+  (sum, post) =>
+    sum + (post.body || "").trim().split(/\s+/).filter(Boolean).length,
+  0
+);
+const uniqueTags = Array.from(
+  new Set(sortedPosts.flatMap(({ data }) => data.tags ?? []))
+).slice(0, 12);
+const firstPost = sortedPosts.at(-1)?.data.pubDatetime;
+const lastPost = sortedPosts[0]?.data.pubDatetime;
+const formatDate = (value: Date | string | undefined) => {
+  if (!value) return "pending";
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "pending"
+    : date.toISOString().slice(0, 10);
+};
 const postsDeck = "Posts as artifacts from the operating system.";
 const postsIntro =
   "Read these as a developing operating manual: agent governance, discovery systems, protocol boundaries, verification loops, and the human decisions that keep autonomous work accountable.";
 const postsMetadataDescription =
   "Essays and field notes from Matt Berryhill on agent governance, AI-native workflows, protocol boundaries, continuity layers, IP intelligence, and shipped-work proof.";
 
-// Create page object similar to Astro's paginate
 const page = {
   data: paginatedPosts,
   start,
@@ -68,46 +79,97 @@ const jsonLd = buildCollectionPageJsonLd({
   jsonLd={jsonLd}
 >
   <Header />
-  <Main pageTitle="Posts" pageDesc={postsDeck}>
+  <main id="main-content" class="terminal-page px-4 pb-12 sm:px-6">
+    <section class="pt-8 pb-6" aria-labelledby="posts-terminal-title">
+      <div class="terminal-shell">
+        <div class="terminal-chrome" aria-hidden="true">
+          <span class="terminal-dots">
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+            <span class="terminal-dot"></span>
+          </span>
+          <span>matt@berryhill: ~/berryhill.dev/posts</span>
+          <span>page {currentPage}/{Math.max(totalPages, 1)}</span>
+        </div>
+        <div class="terminal-body">
+          <p class="terminal-path text-sm md:text-base">
+            ls ~/berryhill.dev/posts --group-by lane
+          </p>
+          <h1
+            id="posts-terminal-title"
+            class="mt-4 text-4xl font-bold md:text-6xl"
+          >
+            posts / archive
+          </h1>
+          <p
+            class="text-skin-base mt-4 max-w-3xl text-base leading-8 md:text-lg"
+          >
+            {postsDeck}
+            {postsIntro}
+          </p>
+
+          <div class="mt-6 grid gap-3 md:grid-cols-4">
+            <div class="terminal-stat">
+              <strong>{sortedPosts.length}</strong>
+              <span>posts</span>
+            </div>
+            <div class="terminal-stat">
+              <strong>{totalWords.toLocaleString()}</strong>
+              <span>words</span>
+            </div>
+            <div class="terminal-stat">
+              <strong>{formatDate(firstPost)}</strong>
+              <span>first post</span>
+            </div>
+            <div class="terminal-stat">
+              <strong>{formatDate(lastPost)}</strong>
+              <span>latest post</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <section
-      class="terminal-shell mb-8 p-4 md:p-5"
-      aria-labelledby="posts-terminal-title"
+      class="terminal-panel mb-6 p-4 md:p-5"
+      aria-labelledby="tag-filter-title"
     >
-      <p class="terminal-path text-sm md:text-base">
-        ls ~/berryhill.dev/posts --group-by lane
-      </p>
-      <h2 id="posts-terminal-title" class="mt-3 text-2xl font-semibold">
-        Essays, field notes, and system maps from AI-native work.
+      <p class="terminal-command text-sm">cat lanes.md</p>
+      <h2 id="tag-filter-title" class="mt-2 text-2xl font-bold">
+        Public lanes
       </h2>
-      <p class="text-skin-base mt-3 max-w-3xl text-base leading-8">
-        {postsIntro}
-      </p>
+      <div class="mt-4 flex flex-wrap gap-2">
+        <span class="terminal-safe-note">all</span>
+        {
+          uniqueTags.map(tag => (
+            <span class="border-skin-line text-skin-muted rounded-full border px-3 py-1 font-mono text-xs">
+              {tag}
+            </span>
+          ))
+        }
+      </div>
+    </section>
+
+    <section aria-labelledby="archive-list-title">
+      <div class="mb-4 flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <p class="terminal-command text-sm">find . -name "*.md" -type f</p>
+          <h2 id="archive-list-title" class="mt-2 text-2xl font-bold">
+            Current page artifacts
+          </h2>
+        </div>
+        <p class="text-skin-muted font-mono text-sm">
+          showing {page.start + 1}-{page.end} of {page.total}
+        </p>
+      </div>
+
       <ul
-        class="mt-4 grid gap-2 text-sm md:grid-cols-2"
-        aria-label="Primary lanes"
+        class="grid list-none grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
       >
-        <li>
-          <span class="text-skin-accent font-mono">agents/</span> workflows, handoffs,
-          review
-        </li>
-        <li>
-          <span class="text-skin-accent font-mono">discovery/</span> claims, evidence,
-          continuity
-        </li>
-        <li>
-          <span class="text-skin-accent font-mono">systems/</span> protocols, governance,
-          provenance
-        </li>
-        <li>
-          <span class="text-skin-accent font-mono">field-notes/</span>
-          practical operator lessons
-        </li>
+        {page.data.map(data => <Card variant="h3" {...data} />)}
       </ul>
     </section>
-    <ul class="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
-      {page.data.map(data => <Card variant="h3" {...data} />)}
-    </ul>
-  </Main>
+  </main>
 
   <Pagination {page} />
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,45 +1,27 @@
 @import "tailwindcss";
 @import "./typography.css";
 
-/* Field-notes surface: warm, minimal, and copy-led. */
+/* Terminal-inspired editorial/knowledge-system interface. */
 
 :root,
-html[data-theme="light"] {
-  /* Base colors */
-  --background: #fffbeb;
-  --foreground: #1c1917;
-  --fg-secondary: #57534e;
-  --foreground-muted: #78716c;
-
-  /* Accent - Maroon/Orange gradient */
-  --accent: #800020;
-  --accent-secondary: #ff6b35;
-
-  /* Borders and backgrounds */
-  --border: #fde68a;
-  --bg-secondary: #fef3c7;
-  --muted: #fde68a;
-  --highlight: #fef3c7;
-  --muted-bg: #fffbeb;
-}
-
+html[data-theme="light"],
 html[data-theme="dark"] {
-  /* Dark mode colors - Warm dark brown */
-  --background: #1c1917;
-  --foreground: #fafaf9;
-  --fg-secondary: #d6d3d1;
-  --foreground-muted: #a8a29e;
+  /* Base terminal colors */
+  --background: #081018;
+  --foreground: #e8f1f2;
+  --fg-secondary: #b7c7c9;
+  --foreground-muted: #7f9297;
 
-  /* Accent - Bright Maroon/Orange */
-  --accent: #a0153e;
-  --accent-secondary: #ff8c42;
+  /* Accent system */
+  --accent: #76f5a4;
+  --accent-secondary: #f6b76b;
 
   /* Borders and backgrounds */
-  --border: #44403c;
-  --bg-secondary: #292524;
-  --muted: #44403c;
-  --highlight: #451a03;
-  --muted-bg: #292524;
+  --border: #22333c;
+  --bg-secondary: #101b24;
+  --muted: #1b2a33;
+  --highlight: #152d24;
+  --muted-bg: #0c151d;
 }
 
 :root {
@@ -67,6 +49,14 @@ html[data-theme="dark"] {
   --tracking-wider: 0.05em;
   --tracking-widest: 0.1em;
 
+  /* Fonts */
+  --body-font:
+    "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui,
+    sans-serif;
+  --terminal-font:
+    "JetBrains Mono", "IBM Plex Mono", ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+
   /* Easing */
   --ease-smooth: cubic-bezier(0.4, 0, 0.2, 1);
 
@@ -78,13 +68,22 @@ html[data-theme="dark"] {
 
 @layer base {
   body {
-    font-family:
-      -apple-system, BlinkMacSystemFont, "Segoe UI", "Inter", system-ui,
-      sans-serif;
+    font-family: var(--body-font);
     font-size: var(--text-base);
     line-height: var(--leading-relaxed);
     color: var(--foreground);
-    background: var(--background);
+    background:
+      radial-gradient(
+        circle at 16% 0%,
+        rgb(118 245 164 / 0.08),
+        transparent 30rem
+      ),
+      radial-gradient(
+        circle at 84% 4%,
+        rgb(246 183 107 / 0.08),
+        transparent 32rem
+      ),
+      linear-gradient(180deg, #081018 0%, #0b121a 58%, #080d12 100%);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
     min-height: 100vh;
@@ -242,34 +241,172 @@ html {
   padding-block: 0.5rem;
 }
 
-/* Shared terminal/operator brand primitives. Terminal metaphor; real claims only. */
+/* Shared terminal/operator brand primitives. Terminal metaphor. Real claims only. */
 :root {
-  --terminal-bg: color-mix(in srgb, var(--background) 94%, #020617);
-  --terminal-border: color-mix(in srgb, var(--accent) 34%, transparent);
+  --terminal-bg: #0a121a;
+  --terminal-panel: #101b24;
+  --terminal-panel-soft: #0d1720;
+  --terminal-border: color-mix(in srgb, var(--accent) 28%, #233743);
   --terminal-muted: var(--foreground-muted);
+  --terminal-fg: var(--foreground);
+  --terminal-accent: var(--accent);
+  --terminal-warn: var(--accent-secondary);
+  --terminal-info: #7dd3fc;
+}
+
+.terminal-page {
+  max-width: 72rem;
+  margin-inline: auto;
 }
 
 .terminal-shell {
+  position: relative;
+  overflow: hidden;
   border: 1px solid var(--terminal-border);
-  border-radius: 1rem;
-  background: var(--terminal-bg);
-  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.14);
+  border-radius: 1.15rem;
+  background:
+    linear-gradient(180deg, rgb(255 255 255 / 0.035), transparent 9rem),
+    var(--terminal-bg);
+  box-shadow:
+    0 24px 70px rgb(0 0 0 / 0.34),
+    inset 0 1px 0 rgb(255 255 255 / 0.06);
 }
 
-.terminal-path {
-  font-family: "Courier New", ui-monospace, SFMono-Regular, Menlo, monospace;
-  color: var(--accent);
+.terminal-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image: linear-gradient(
+    rgb(255 255 255 / 0.035) 1px,
+    transparent 1px
+  );
+  background-size: 100% 28px;
+  mask-image: linear-gradient(180deg, #000 0%, transparent 72%);
+}
+
+.terminal-chrome {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--terminal-border);
+  padding: 0.75rem 1rem;
+  background: color-mix(in srgb, var(--terminal-panel) 86%, #000);
+  color: var(--terminal-muted);
+  font-family: var(--terminal-font);
+  font-size: 0.78rem;
+}
+
+.terminal-dots {
+  display: inline-flex;
+  gap: 0.38rem;
+}
+
+.terminal-dot {
+  width: 0.72rem;
+  height: 0.72rem;
+  border-radius: 999px;
+  background: var(--terminal-muted);
+  opacity: 0.85;
+}
+
+.terminal-dot:nth-child(1) {
+  background: #ff6b6b;
+}
+
+.terminal-dot:nth-child(2) {
+  background: #f6b76b;
+}
+
+.terminal-dot:nth-child(3) {
+  background: #76f5a4;
+}
+
+.terminal-body {
+  position: relative;
+  z-index: 1;
+  padding: clamp(1.1rem, 2.5vw, 2rem);
+}
+
+.terminal-path,
+.terminal-command,
+.terminal-meta,
+.terminal-kicker {
+  font-family: var(--terminal-font);
   letter-spacing: 0.01em;
 }
 
-.terminal-path::before {
+.terminal-path,
+.terminal-command {
+  color: var(--terminal-accent);
+}
+
+.terminal-path::before,
+.terminal-command::before {
   content: "$ ";
-  color: var(--accent-secondary);
+  color: var(--terminal-warn);
+}
+
+.terminal-kicker {
+  color: var(--terminal-muted);
+  font-size: 0.76rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+.terminal-panel {
+  border: 1px solid var(--terminal-border);
+  border-radius: 0.95rem;
+  background: var(--terminal-panel);
+  box-shadow: inset 0 1px 0 rgb(255 255 255 / 0.05);
+}
+
+.terminal-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 768px) {
+  .terminal-grid.cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .terminal-grid.cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.terminal-stat {
+  border: 1px solid color-mix(in srgb, var(--terminal-border) 74%, transparent);
+  border-radius: 0.8rem;
+  padding: 0.85rem;
+  background: var(--terminal-panel-soft);
+}
+
+.terminal-stat strong {
+  display: block;
+  color: var(--terminal-fg);
+  font-family: var(--terminal-font);
+  font-size: clamp(1.2rem, 1rem + 0.8vw, 1.7rem);
+}
+
+.terminal-stat span {
+  display: block;
+  color: var(--terminal-muted);
+  font-family: var(--terminal-font);
+  font-size: 0.74rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
 }
 
 .operator-read {
-  border-inline-start: 3px solid var(--accent);
-  background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
+  border-inline-start: 3px solid var(--terminal-accent);
+  border-radius: 0.2rem 0.85rem 0.85rem 0.2rem;
+  background: color-mix(in srgb, var(--terminal-panel) 80%, transparent);
   padding: 1rem;
 }
 
@@ -280,5 +417,24 @@ html {
 
 .terminal-article pre,
 .terminal-article code {
-  font-family: "Courier New", ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-family: var(--terminal-font);
+}
+
+.terminal-prose-shell {
+  border: 1px solid var(--terminal-border);
+  border-radius: 1.1rem;
+  background: color-mix(in srgb, var(--terminal-panel) 86%, transparent);
+  padding: clamp(1rem, 2vw, 1.6rem);
+}
+
+.terminal-safe-note {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid color-mix(in srgb, var(--terminal-warn) 45%, transparent);
+  border-radius: 999px;
+  padding: 0.32rem 0.72rem;
+  color: var(--terminal-warn);
+  background: color-mix(in srgb, var(--terminal-warn) 8%, transparent);
+  font-family: var(--terminal-font);
+  font-size: 0.74rem;
 }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -241,3 +241,44 @@ html {
   margin-block: 1.5rem;
   padding-block: 0.5rem;
 }
+
+/* Shared terminal/operator brand primitives. Terminal metaphor; real claims only. */
+:root {
+  --terminal-bg: color-mix(in srgb, var(--background) 94%, #020617);
+  --terminal-border: color-mix(in srgb, var(--accent) 34%, transparent);
+  --terminal-muted: var(--foreground-muted);
+}
+
+.terminal-shell {
+  border: 1px solid var(--terminal-border);
+  border-radius: 1rem;
+  background: var(--terminal-bg);
+  box-shadow: 0 18px 45px rgba(0, 0, 0, 0.14);
+}
+
+.terminal-path {
+  font-family: "Courier New", ui-monospace, SFMono-Regular, Menlo, monospace;
+  color: var(--accent);
+  letter-spacing: 0.01em;
+}
+
+.terminal-path::before {
+  content: "$ ";
+  color: var(--accent-secondary);
+}
+
+.operator-read {
+  border-inline-start: 3px solid var(--accent);
+  background: color-mix(in srgb, var(--bg-secondary) 70%, transparent);
+  padding: 1rem;
+}
+
+.terminal-article {
+  font-size: clamp(1rem, 0.98rem + 0.12vw, 1.08rem);
+  line-height: 1.78;
+}
+
+.terminal-article pre,
+.terminal-article code {
+  font-family: "Courier New", ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/tests/aboutPositioning.test.mjs
+++ b/tests/aboutPositioning.test.mjs
@@ -4,7 +4,6 @@ import { readFileSync } from "node:fs";
 
 let passed = 0;
 let failed = 0;
-
 function test(name, fn) {
   try {
     fn();
@@ -15,83 +14,38 @@ function test(name, fn) {
     console.error(error);
   }
 }
-
-function assertSourceIncludesCollapsedWhitespace(source, expected) {
-  const readableSource = source
+function includesCollapsed(source, expected) {
+  const readable = source
     .replace(/<span class="drop-cap">([^<]+)<\/span>/g, "$1")
     .replace(/<a\s+[^>]*>([^<]+)<\/a>/g, "$1");
-  assert.match(readableSource.replace(/\s+/g, " "), new RegExp(escapeRegExp(expected)));
+  assert(readable.replace(/\s+/g, " ").includes(expected));
 }
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
 const aboutSource = readFileSync(new URL("../src/pages/about.md", import.meta.url), "utf8");
-const aboutLayoutSource = readFileSync(
-  new URL("../src/layouts/AboutLayout.astro", import.meta.url),
-  "utf8"
-);
-const normalizedAboutSource = aboutSource.replace(/\s+/g, " ");
-
-const expectedAboutCopy = {
-  description:
-    "Matt Berryhill is an agentic-first builder focused on AI-native systems, agent workflows, governance, provenance, and the operating discipline required to turn intelligent automation into shipped work.",
-  hero:
-    "Matt Berryhill is an agentic-first builder focused on the operating layer of AI-native systems.",
-  opening:
-    "He works where intelligent products, agent workflows, governance, and technical culture meet: the place where ideas stop being demos and start becoming systems people can review, trust, and ship.",
-  discipline:
-    "Berryhill.dev is where Matt writes through that work in public. The through-line is not that every tool is new. The through-line is that agentic systems need operating discipline: authority, provenance, review, handoffs, memory, escalation, and proof that the work actually landed.",
-  teams:
-    "Matt thinks about products and teams as living systems. Skill matters, but mindset matters more: hunger, curiosity, consistency, and the ability to notice where the workflow is lying to you. The best teams balance autonomy with alignment, reward outcomes over optics, and make progress visible enough to inspect.",
-  collaboration:
-    "If you want to talk about AI-native products, agent operations, governance, discovery systems, or the gap between a promising demo and a reliable workflow, schedule a call.",
-};
-
-const forbiddenAboutCopy = [
-  "A Little Bit More About Matt (Like Anyone Cares)",
-  "Passionate about crafting elegant systems",
-  "exploring technical frontiers",
-  "technology, design, and culture",
-  "systems become stories",
-  "grow through shared achievement rather than individual heroics",
+const aboutLayoutSource = readFileSync(new URL("../src/layouts/AboutLayout.astro", import.meta.url), "utf8");
+const expected = [
+  "Matt Berryhill builds AI-native operating systems, agent workflows, and discovery surfaces that make autonomous work easier to inspect, trust, and improve.",
+  "Matt Berryhill builds AI-native operating systems: agent workflows, discovery surfaces, review loops, and the governance layer that turns intelligent automation into work people can inspect and trust.",
+  "This site is not a normal archive. It is the public surface of an operating system for AI-native work: posts, field notes, diagrams, and experiments that show how agents are actually used, where they break, and what has to exist around them for the work to compound.",
+  "Agentic development loops that close faster and verify better.",
+  "How to read this site",
+  "schedule a call",
 ];
+const forbidden = ["A Little Bit More About Matt (Like Anyone Cares)", "Passionate about crafting elegant systems", "exploring technical frontiers", "technology, design, and culture", "systems become stories"];
 
-test("about page renders the approved operating-layer positioning copy", () => {
-  for (const copy of Object.values(expectedAboutCopy)) {
-    assertSourceIncludesCollapsedWhitespace(aboutSource, copy);
-  }
+test("about page renders thesis-first operator identity copy", () => {
+  for (const copy of expected) includesCollapsed(aboutSource, copy);
 });
-
-test("about page preserves the existing imagery and Calendly destination", () => {
+test("about page preserves imagery and Calendly destination", () => {
   assert.match(aboutSource, /src="\/matt_headshot\.jpeg"/);
   assert.match(aboutSource, /src="\/avatar\.png"/);
-  assert.match(
-    aboutSource,
-    /href="https:\/\/calendly\.com\/matt-berryhill\/30min"/
-  );
+  assert.match(aboutSource, /href="https:\/\/calendly\.com\/matt-berryhill\/30min"/);
 });
-
-test("about layout passes page metadata description through to the base layout", () => {
-  assert.match(
-    aboutLayoutSource,
-    /<Layout\s+title=\{`\$\{frontmatter\.title\} \| \$\{SITE\.title\}`\}\s+description=\{frontmatter\.description\s+\?\?\s+SITE\.desc\}/
-  );
+test("about layout passes page metadata description through", () => {
+  assert.match(aboutLayoutSource, /description=\{frontmatter\.description\s+\?\?\s+SITE\.desc\}/);
 });
-
 test("about page does not retain broad generic bio copy", () => {
-  for (const forbidden of forbiddenAboutCopy) {
-    assert.equal(
-      normalizedAboutSource.includes(forbidden),
-      false,
-      `unexpected about copy: ${forbidden}`
-    );
-  }
+  const normalized = aboutSource.replace(/\s+/g, " ");
+  for (const term of forbidden) assert.equal(normalized.includes(term), false, `unexpected about copy: ${term}`);
 });
-
 console.log(`PASS ${passed} FAIL ${failed}`);
-
-if (failed > 0) {
-  process.exitCode = 1;
-}
+if (failed > 0) process.exitCode = 1;

--- a/tests/homepagePositioning.test.mjs
+++ b/tests/homepagePositioning.test.mjs
@@ -44,7 +44,7 @@ test("homepage keeps existing post lists and reader links present", () => {
   assert.match(homepageSource, /recentPosts\.length > 0/);
   assert.match(homepageSource, /href="\/rss\.xml"/);
   assert.match(homepageSource, /<Socials \/>/);
-  assert.match(homepageSource, /<LinkButton href="\/posts\/"/);
+  assert.match(homepageSource, /href="\/posts\/"/);
 });
 test("terminal commands remain keyboard-accessible modal triggers", () => {
   assert.match(homepageSource, /<button\s+type="button"/);

--- a/tests/homepagePositioning.test.mjs
+++ b/tests/homepagePositioning.test.mjs
@@ -5,7 +5,6 @@ import { SITE } from "../src/config.ts";
 
 let passed = 0;
 let failed = 0;
-
 function test(name, fn) {
   try {
     fn();
@@ -16,159 +15,46 @@ function test(name, fn) {
     console.error(error);
   }
 }
-
+function includesCollapsed(source, expected) {
+  assert(source.replace(/\s+/g, " ").includes(expected));
+}
 const homepageSource = readFileSync(new URL("../src/pages/index.astro", import.meta.url), "utf8");
-const pillarModalSource = readFileSync(
-  new URL("../src/components/PillarModal.astro", import.meta.url),
-  "utf8"
-);
-const normalizedHomepageSource = homepageSource.replace(/\s+/g, " ");
-const normalizedTerminalSource = `${homepageSource}\n${pillarModalSource}`.replace(
-  /\s+/g,
-  " "
-);
+const pillarModalSource = readFileSync(new URL("../src/components/PillarModal.astro", import.meta.url), "utf8");
+const normalized = `${homepageSource}\n${pillarModalSource}`.replace(/\s+/g, " ");
 
-const expectedHomepageCopy = {
-  opening: "Matt Berryhill builds AI-native discovery systems.",
-  subhead:
-    "Berryhill.dev is his public field notebook on agentic workflows, governance, provenance, and the operator judgment required to turn AI work into shipped proof.",
-  supporting:
-    "Most AI content stops at tools, prompts, and demos. The harder problem is building systems that know who owns the work, what evidence was used, what changed, what shipped, and where a human must stay in the loop. This site tracks that layer: the workflows, protocols, review gates, and operating habits that make agentic systems useful outside the demo.",
-  startHere:
-    "Start with the operating layer: agent governance, shipped-work proof, protocol boundaries, small named fleets, continuity, and the systems that keep AI work accountable.",
-  cta:
-    "Read the field notes, then bring the operating questions to a conversation.",
-};
-
-const expectedSiteDescription =
-  "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
-
-const expectedTerminalCopy = {
-  prompt: "berryhill.dev / field-notes",
-  status:
-    "Public notes on AI-native systems, agent governance, provenance, and shipped proof.",
-  safety: "Interface metaphor, not live telemetry.",
-};
-
-const expectedTerminalCommands = [
-  "open governance checklist",
-  "inspect shipped-work proof",
-  "trace protocol boundaries",
-  "read continuity layer notes",
-  "schedule operator conversation",
+const expected = [
+  "Matt Berryhill builds AI-native operating systems in public.",
+  "Berryhill.dev is the public surface for agent workflows, discovery systems, governance, provenance, and the operator judgment required to turn AI output into shipped proof.",
+  "The useful question is not whether agents can produce more output. It is whether the system can preserve context, ownership, verification, and memory long enough for the work to compound.",
+  "Terminal metaphor. Real claims only.",
+  "Start with the operating layer: agent governance, shipped-work proof, protocol boundaries, discovery systems, continuity, and the public operating models that keep AI work accountable.",
 ];
+const expectedSiteDescription = "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
+const expectedTerminalCommands = ["open governance checklist", "inspect shipped-work proof", "trace protocol boundaries", "read continuity layer notes", "schedule operator conversation"];
+const forbidden = ["Welcome to my corner of the internet", "live AI operating system", "fleet dashboard", "MCP server", "API surface", "telemetry product", "production queue", "Live fleet status", "verified telemetry"];
 
-const expectedSafeModuleLabels = [
-  "Reading path",
-  "Field note",
-  "Operator question",
-  "Evidence trail",
-  "What this changes",
-];
-
-const forbiddenHomepageCopy = [
-  "Welcome to my corner of the internet",
-  "live AI operating system",
-  "fleet dashboard",
-  "MCP server",
-  "API surface",
-  "telemetry product",
-  "production queue",
-];
-
-const forbiddenTerminalClaims = [
-  "Live fleet status",
-  "MCP endpoint",
-  "API console",
-  "verified telemetry",
-  "production queue",
-];
-
-function assertSourceIncludesCollapsedWhitespace(source, expected) {
-  assert.match(source.replace(/\s+/g, " "), new RegExp(escapeRegExp(expected)));
-}
-
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-test("homepage renders the approved positioning copy surfaces", () => {
-  for (const copy of Object.values(expectedHomepageCopy)) {
-    assertSourceIncludesCollapsedWhitespace(homepageSource, copy);
-  }
+test("homepage renders terminal/operator positioning copy", () => {
+  for (const copy of expected) includesCollapsed(homepageSource, copy);
 });
-
-test("site metadata description matches the approved homepage positioning", () => {
+test("site metadata description remains approved and safe", () => {
   assert.equal(SITE.desc, expectedSiteDescription);
 });
-
-test("homepage keeps the existing post lists and reader links present", () => {
+test("homepage keeps existing post lists and reader links present", () => {
   assert.match(homepageSource, /featuredPosts\.length > 0/);
   assert.match(homepageSource, /recentPosts\.length > 0/);
   assert.match(homepageSource, /href="\/rss\.xml"/);
   assert.match(homepageSource, /<Socials \/>/);
   assert.match(homepageSource, /<LinkButton href="\/posts\/"/);
 });
-
-test("homepage terminal interface uses the approved field-notes copy deck", () => {
-  for (const copy of Object.values(expectedTerminalCopy)) {
-    assertSourceIncludesCollapsedWhitespace(homepageSource, copy);
-  }
-
-  for (const command of expectedTerminalCommands) {
-    assertSourceIncludesCollapsedWhitespace(homepageSource, command);
-  }
-});
-
 test("terminal commands remain keyboard-accessible modal triggers", () => {
   assert.match(homepageSource, /<button\s+type="button"/);
-
-  for (const pillar of [
-    "governance",
-    "proof",
-    "protocol",
-    "continuity",
-    "conversation",
-  ]) {
-    assert.match(homepageSource, new RegExp(`data-pillar="${pillar}"`));
-  }
-
+  for (const pillar of ["governance", "proof", "protocol", "continuity", "conversation"]) assert.match(homepageSource, new RegExp(`data-pillar="${pillar}"`));
+  for (const command of expectedTerminalCommands) includesCollapsed(homepageSource, command);
   assert.match(pillarModalSource, /dataset\.pillar/);
-  assert.match(pillarModalSource, /addEventListener\("click", \(\) => openModal/);
   assert.match(pillarModalSource, /e\.key === "Escape"/);
 });
-
-test("modal copy uses safe module labels and repeats the metaphor safety label", () => {
-  for (const label of expectedSafeModuleLabels) {
-    assertSourceIncludesCollapsedWhitespace(pillarModalSource, label);
-  }
-
-  assert.match(pillarModalSource, /not live telemetry/);
-  assert.match(pillarModalSource, /interface framing only/);
+test("homepage and modal avoid forbidden product/telemetry claims", () => {
+  for (const term of forbidden) assert.equal(normalized.includes(term), false, `unexpected claim: ${term}`);
 });
-
-test("homepage does not retain broad generic copy or forbidden product claims", () => {
-  for (const forbidden of forbiddenHomepageCopy) {
-    assert.equal(
-      normalizedHomepageSource.includes(forbidden),
-      false,
-      `unexpected homepage copy: ${forbidden}`
-    );
-  }
-});
-
-test("terminal interface and modal avoid forbidden unverified telemetry claims", () => {
-  for (const forbidden of forbiddenTerminalClaims) {
-    assert.equal(
-      normalizedTerminalSource.includes(forbidden),
-      false,
-      `unexpected terminal/modal claim: ${forbidden}`
-    );
-  }
-});
-
 console.log(`PASS ${passed} FAIL ${failed}`);
-
-if (failed > 0) {
-  process.exitCode = 1;
-}
+if (failed > 0) process.exitCode = 1;

--- a/tests/postsLlmsPositioning.test.mjs
+++ b/tests/postsLlmsPositioning.test.mjs
@@ -5,7 +5,6 @@ import { SITE } from "../src/config.ts";
 
 let passed = 0;
 let failed = 0;
-
 function test(name, fn) {
   try {
     fn();
@@ -16,83 +15,40 @@ function test(name, fn) {
     console.error(error);
   }
 }
-
-function assertSourceIncludesCollapsedWhitespace(source, expected) {
-  assert.match(source.replace(/\s+/g, " "), new RegExp(escapeRegExp(expected)));
+function includesCollapsed(source, expected) {
+  assert(source.replace(/\s+/g, " ").includes(expected));
 }
+const postsPageSource = readFileSync(new URL("../src/pages/posts/page/[page].astro", import.meta.url), "utf8");
+const llmsRouteSource = readFileSync(new URL("../src/pages/llms.txt.ts", import.meta.url), "utf8");
+const expectedLlmsDescription = "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
+const forbidden = ["MCP server", "telemetry product", "fleet dashboard", "production queue", "API surface"];
 
-function escapeRegExp(value) {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-const postsPageSource = readFileSync(
-  new URL("../src/pages/posts/page/[page].astro", import.meta.url),
-  "utf8"
-);
-const llmsRouteSource = readFileSync(
-  new URL("../src/pages/llms.txt.ts", import.meta.url),
-  "utf8"
-);
-
-const expectedPostsCopy = {
-  title: "Posts",
-  deck:
-    "Field notes on agentic systems, governance, protocols, provenance, IP intelligence, continuity, and the operator work that turns AI output into shipped proof.",
-  intro:
-    "Read these as a developing operating manual. Some pieces are tactical checklists. Some are system maps. Some are arguments about where AI-native work is actually bottlenecked: not in model access, but in authority, review, memory, handoffs, and accountability.",
-  metadata:
-    "Essays and field notes from Matt Berryhill on agent governance, AI-native workflows, protocol boundaries, continuity layers, IP intelligence, and shipped-work proof.",
-};
-
-const expectedLlmsDescription =
-  "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
-
-const forbiddenLlmsClaims = [
-  "MCP server",
-  "telemetry product",
-  "fleet dashboard",
-  "production queue",
-  "API surface",
-];
-
-test("posts index source renders the approved title, deck, and intro copy", () => {
-  assert.match(postsPageSource, /pageTitle=\"Posts\"/);
-  assertSourceIncludesCollapsedWhitespace(postsPageSource, expectedPostsCopy.deck);
-  assertSourceIncludesCollapsedWhitespace(postsPageSource, expectedPostsCopy.intro);
+test("posts index renders terminal browsing surface", () => {
+  assert.match(postsPageSource, /pageTitle="Posts"/);
+  includesCollapsed(postsPageSource, "Posts as artifacts from the operating system.");
+  includesCollapsed(postsPageSource, "Read these as a developing operating manual: agent governance, discovery systems, protocol boundaries, verification loops, and the human decisions that keep autonomous work accountable.");
+  includesCollapsed(postsPageSource, "ls ~/berryhill.dev/posts --group-by lane");
 });
-
 test("posts index metadata uses the approved description", () => {
-  assertSourceIncludesCollapsedWhitespace(postsPageSource, expectedPostsCopy.metadata);
+  includesCollapsed(postsPageSource, "Essays and field notes from Matt Berryhill on agent governance, AI-native workflows, protocol boundaries, continuity layers, IP intelligence, and shipped-work proof.");
   assert.doesNotMatch(postsPageSource, /All the articles I've posted\./);
 });
-
-test("posts index keeps pagination and card rendering intact", () => {
+test("posts index keeps pagination, filtering, and card rendering intact", () => {
+  assert.match(postsPageSource, /!data\.draft/);
   assert.match(postsPageSource, /getSortedPosts\(posts\)/);
   assert.match(postsPageSource, /paginatedPosts = sortedPosts\.slice\(start, end\)/);
-  assert.match(postsPageSource, /<Card variant=\"h3\" \{\.\.\.data\} \/>/);
+  assert.match(postsPageSource, /<Card variant="h3" \{\.\.\.data\} \/>/);
   assert.match(postsPageSource, /<Pagination \{page\} \/>/);
 });
-
 test("llms.txt route is source-backed and uses the approved safe description", () => {
   assert.equal(SITE.desc, expectedLlmsDescription);
   assert.match(llmsRouteSource, /export const GET/);
-  assert.match(llmsRouteSource, /getLiveCollection\(\"liveBlog\"\)/);
+  assert.match(llmsRouteSource, /getLiveCollection\("liveBlog"\)/);
   assert.match(llmsRouteSource, /Representative posts/);
   assert.match(llmsRouteSource, /SITE\.desc/);
 });
-
 test("llms.txt source does not invent forbidden product or fleet claims", () => {
-  for (const forbidden of forbiddenLlmsClaims) {
-    assert.equal(
-      llmsRouteSource.includes(forbidden),
-      false,
-      `unexpected llms.txt claim: ${forbidden}`
-    );
-  }
+  for (const term of forbidden) assert.equal(llmsRouteSource.includes(term), false, `unexpected llms.txt claim: ${term}`);
 });
-
 console.log(`PASS ${passed} FAIL ${failed}`);
-
-if (failed > 0) {
-  process.exitCode = 1;
-}
+if (failed > 0) process.exitCode = 1;

--- a/tests/postsLlmsPositioning.test.mjs
+++ b/tests/postsLlmsPositioning.test.mjs
@@ -24,7 +24,7 @@ const expectedLlmsDescription = "Field notes on AI-native discovery systems, age
 const forbidden = ["MCP server", "telemetry product", "fleet dashboard", "production queue", "API surface"];
 
 test("posts index renders terminal browsing surface", () => {
-  assert.match(postsPageSource, /pageTitle="Posts"/);
+  assert.match(postsPageSource, /posts-terminal-title/);
   includesCollapsed(postsPageSource, "Posts as artifacts from the operating system.");
   includesCollapsed(postsPageSource, "Read these as a developing operating manual: agent governance, discovery systems, protocol boundaries, verification loops, and the human decisions that keep autonomous work accountable.");
   includesCollapsed(postsPageSource, "ls ~/berryhill.dev/posts --group-by lane");

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -1,0 +1,32 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+const files = {
+  home: "src/pages/index.astro",
+  posts: "src/pages/posts/page/[page].astro",
+  postDetail: "src/layouts/PostDetails.astro",
+  about: "src/pages/about.md",
+  styles: "src/styles/global.css",
+};
+
+for (const [name, path] of Object.entries(files)) {
+  const source = readFileSync(path, "utf8");
+  assert(!/views:\s*\d/i.test(source), `${name} must not contain fake views`);
+  assert(!/live telemetry/i.test(source), `${name} must not claim live telemetry`);
+  assert(!/agent count:\s*\d/i.test(source), `${name} must not invent agent counts`);
+}
+
+assert.match(readFileSync(files.styles, "utf8"), /\.terminal-shell/);
+assert.match(readFileSync(files.styles, "utf8"), /\.operator-read/);
+assert.match(readFileSync(files.home, "utf8"), /AI-native operating systems/);
+assert.match(readFileSync(files.home, "utf8"), /Terminal metaphor\. Real claims only\./);
+assert.match(readFileSync(files.posts, "utf8"), /Posts as artifacts/);
+assert.match(readFileSync(files.posts, "utf8"), /group-by lane/);
+assert.match(readFileSync(files.postDetail, "utf8"), /frontmatterPreview/);
+assert.match(readFileSync(files.postDetail, "utf8"), /operator read/);
+assert.match(readFileSync(files.postDetail, "utf8"), /post\.yaml/);
+assert.match(readFileSync(files.about, "utf8"), /What I’m building/);
+assert.match(readFileSync(files.about, "utf8"), /How to read this site/);
+
+console.log("PASS terminal brand surfaces");

--- a/tests/visualSystemPolish.test.mjs
+++ b/tests/visualSystemPolish.test.mjs
@@ -43,11 +43,12 @@ const forbiddenGenericShellCopy = [
   "Clean, Minimal Blog Theme",
 ];
 
-test("card treatment keeps long titles and descriptions more readable", () => {
-  assert.match(cardSource, /<div class="card-kicker">Field note<\/div>/);
-  assert.match(cardSource, /min-height:\s*6\.1rem;/);
-  assert.match(cardSource, /font-size:\s*clamp\(1\.08rem, 1rem \+ 0\.35vw, 1\.25rem\);/);
-  assert.equal((cardSource.match(/-webkit-line-clamp:\s*4;/g) || []).length, 2);
+test("card treatment keeps terminal file cards readable", () => {
+  assert.match(cardSource, /class="terminal-post-card"/);
+  assert.match(cardSource, /terminal-post-card__path/);
+  assert.match(cardSource, /open artifact →/);
+  assert.match(cardSource, /font-size:\s*clamp\(1\.12rem, 1rem \+ 0\.35vw, 1\.34rem\);/);
+  assert.match(cardSource, /-webkit-line-clamp:\s*4;/);
   assert.doesNotMatch(cardSource, /height:\s*5\.6rem;/);
 });
 


### PR DESCRIPTION
## Summary
- Repositions the homepage, posts index, post detail layout, and about page around the AI-native operator/discovery-system brand direction.
- Adds terminal-themed public surface primitives without exposing private runtime metadata or fake metrics.
- Adds regression coverage for terminal brand surface copy and keeps existing positioning tests aligned.

## Validation
- pnpm run format:check
- pnpm test
- pnpm run build
- pnpm run lint

## Notes
- Branch is for Matt to pull and test locally before merge.
