### PR TITLE
Implement terminal brand surfaces

### DIFF
--- a/docs/ai-discovery-content-slate.md
+++ b/docs/ai-discovery-content-slate.md
@@ -16,6 +16,8 @@ Topical authority builds through three mechanisms:
 
 This slate defines the clusters, names the posts that build each one, and sets the linkage and citation rules that govern future content.
 
+Public terminal-shell surfaces should be framed as a brand interface metaphor for Matt's operator/workflow positioning: a way to make the site feel like a working field console. They are not evidence of private runtime state, production queues, fleet activity, or live telemetry unless a public implementation and explicit acceptance criteria back the displayed values.
+
 ---
 
 ## Cluster Definitions and Candidate Posts
@@ -196,7 +198,11 @@ This slate should be reviewed quarterly or after every 3–5 new published posts
 - Add new candidate posts as the content corpus grows
 - Update /llms.txt representative section when new qualifying posts publish
 - Adjust cluster boundaries if the content strategy shifts
-- Verify archive, tag, and card/page-shell framing still presents the corpus as field notes, operating questions, and evidence trails rather than generic blog inventory.
+- Verify archive, tag, card/page-shell, terminal public surface, and homepage-derived state-label framing still presents the corpus as field notes, operating questions, and evidence trails rather than generic blog inventory.
+
+### Public Surface Integrity
+
+Public terminal surfaces may only display values derived from public site data, such as published post count, tag count, latest post date, total word count, frontmatter previews, and per-post word count. Do not invent fake views, fake agent counts, private fleet dashboards, production queue claims, live telemetry, or verified telemetry. Any telemetry-style claim must be backed by a public implementation and acceptance criteria before it appears on the site.
 
 ---
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -74,8 +74,8 @@ const jsonLd = buildWebSiteJsonLd({
           >
             Berryhill.dev is the public surface for agent workflows, discovery
             systems, governance, provenance, and the operator judgment required
-            to turn AI output into shipped proof. The new shell makes that
-            surface feel like a working terminal, not a brochure.
+            to turn AI output into shipped proof. The terminal shell makes that
+            surface feel like a working interface, not a brochure.
           </p>
 
           <div class="mt-6 grid gap-3 md:grid-cols-3" aria-label="Site state">

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -10,23 +10,41 @@ const files = {
   styles: "src/styles/global.css",
 };
 
-for (const [name, path] of Object.entries(files)) {
-  const source = readFileSync(path, "utf8");
-  assert(!/views:\s*\d/i.test(source), `${name} must not contain fake views`);
-  assert(!/live telemetry/i.test(source), `${name} must not claim live telemetry`);
-  assert(!/agent count:\s*\d/i.test(source), `${name} must not invent agent counts`);
+const publicSurfaceSources = Object.fromEntries(
+  Object.entries(files).map(([name, path]) => [name, readFileSync(path, "utf8")])
+);
+
+const forbiddenPublicClaims = [
+  [/views:\s*\d/i, "fake views"],
+  [/live telemetry/i, "live telemetry"],
+  [/agent count:\s*\d/i, "invented agent counts"],
+  [/fleet dashboard/i, "private fleet dashboard"],
+  [/production queue/i, "private production queue"],
+  [/verified telemetry/i, "unverified telemetry"],
+];
+
+for (const [name, source] of Object.entries(publicSurfaceSources)) {
+  for (const [pattern, label] of forbiddenPublicClaims) {
+    assert.doesNotMatch(source, pattern, `${name} must not contain ${label}`);
+  }
 }
 
-assert.match(readFileSync(files.styles, "utf8"), /\.terminal-shell/);
-assert.match(readFileSync(files.styles, "utf8"), /\.operator-read/);
-assert.match(readFileSync(files.home, "utf8"), /AI-native operating systems/);
-assert.match(readFileSync(files.home, "utf8"), /Terminal metaphor\. Real claims only\./);
-assert.match(readFileSync(files.posts, "utf8"), /Posts as artifacts/);
-assert.match(readFileSync(files.posts, "utf8"), /group-by lane/);
-assert.match(readFileSync(files.postDetail, "utf8"), /frontmatterPreview/);
-assert.match(readFileSync(files.postDetail, "utf8"), /operator read/);
-assert.match(readFileSync(files.postDetail, "utf8"), /post\.yaml/);
-assert.match(readFileSync(files.about, "utf8"), /What I’m building/);
-assert.match(readFileSync(files.about, "utf8"), /How to read this site/);
+assert.match(publicSurfaceSources.styles, /\.terminal-shell/);
+assert.match(publicSurfaceSources.styles, /\.operator-read/);
+assert.match(publicSurfaceSources.home, /AI-native operating systems/);
+assert.match(publicSurfaceSources.home, /Terminal metaphor\. Real claims only\./);
+assert.match(publicSurfaceSources.home, /sortedPosts\.length/);
+assert.match(publicSurfaceSources.home, /tagCount/);
+assert.match(publicSurfaceSources.home, /lastPostLabel/);
+assert.match(publicSurfaceSources.posts, /Posts as artifacts/);
+assert.match(publicSurfaceSources.posts, /group-by lane/);
+assert.match(publicSurfaceSources.posts, /totalWords/);
+assert.match(publicSurfaceSources.posts, /sortedPosts\.length/);
+assert.match(publicSurfaceSources.postDetail, /frontmatterPreview/);
+assert.match(publicSurfaceSources.postDetail, /operator read/);
+assert.match(publicSurfaceSources.postDetail, /post\.yaml/);
+assert.match(publicSurfaceSources.postDetail, /wordCount/);
+assert.match(publicSurfaceSources.about, /What I’m building/);
+assert.match(publicSurfaceSources.about, /How to read this site/);
 
 console.log("PASS terminal brand surfaces");


### PR DESCRIPTION
Closes #71

## Source issue
- https://github.com/berryhill/bd-site/issues/71

## Classification
- frontend / brand-surface / content-positioning UI
- Path boundary: app/source-code-touching plus docs/test updates; no deployment, secrets, API, workflow, or live content/PVC changes.

## Prior PR audit / decision
- Re-ran all-state PR audit before final push/update:
  - `gh pr list --repo berryhill/bd-site --state all --search '71' ...` returned one clean open PR: #72, `feature/issue-71-terminal-brand-surfaces` -> `main`.
  - `gh pr list --repo berryhill/bd-site --state all --head feature/issue-71-terminal-brand-surfaces ...` returned the same clean open PR #72.
- Decision: update clean open PR #72 rather than open or reopen another PR. No contaminated/closed PR was found for this issue/head branch.

## Code changes
- Refines the homepage terminal shell copy so the site reads as a public operator interface instead of a generic blog/brochure.
- Keeps public claims grounded in public site data: published artifact count, tag count, latest post label, and real indexed word count.
- Expands `tests/terminalBrandSurfaces.test.mjs` so public terminal surfaces reject fake public metrics and private runtime claims, including fake views, live/verified telemetry, invented agent counts, private fleet dashboard language, and production queue claims.
- Adds regression assertions that the homepage, posts index, post detail layout, about copy, and shared terminal styling preserve the intended brand surface.

## Doc reconciliation actions
- Updated `docs/ai-discovery-content-slate.md` with a public terminal-shell framing rule: terminal surfaces are a brand interface metaphor for Matt's operator/workflow positioning, not proof of private runtime state unless explicitly implemented and accepted.
- Added a Public Surface Integrity section limiting public terminal values to public site data and forbidding fake views, fake agent counts, private fleet/queue claims, and unverified telemetry.
- Added maintenance guidance to keep archive, tag, card/page-shell, terminal public surface, and homepage-derived state-label framing aligned with field notes, operating questions, and evidence trails.

## Destructive-diff guard
- Workdir verified as the approved persistent task worktree: `/home/silas/.hermes/profiles/luca/workspace/worktrees/berryhill/bd-site/t_0a5b8de`.
- Integration branch: `main` (`origin/dev` was not present).
- Branch base: merge-base equals current `origin/main` (`e99c47878aad6c190e99b7e0fe1e7632f0c82c4e`).
- Ahead/behind vs integration: `0 2` from `git rev-list --left-right --count origin/main...HEAD`.
- Diff guard output:
  - `git diff --name-status origin/main...HEAD`
    - `M docs/ai-discovery-content-slate.md`
    - `M src/pages/index.astro`
    - `M tests/terminalBrandSurfaces.test.mjs`
  - `git diff --stat origin/main...HEAD`
    - `3 files changed, 43 insertions(+), 19 deletions(-)`
- No deleted source/config/onboarding files; no `.github/workflows/*` changes. `gh auth status` shows `repo` and `workflow` scopes regardless.

## Validation
- `pnpm test` passed, including `PASS terminal brand surfaces`.
- `pnpm run lint` passed.
- `pnpm run format:check` passed (`All matched files use Prettier code style!`).
- `pnpm run build` passed (`astro build`, server build complete).
