### PR TITLE
Fix pinned post styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/homepagePosts.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:seo-crawl-surface": "node scripts/checkSeoCrawlSurface.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,25 +7,19 @@ import getSortedPosts from "@/utils/getSortedPosts";
 import { getPath } from "@/utils/getPath";
 import { SITE } from "@/config";
 import { buildWebSiteJsonLd } from "@/utils/structuredData";
+import {
+  formatHomepageDate,
+  getPostWordCount,
+  getReadMinutes,
+  selectHomepagePosts,
+} from "@/utils/homepagePosts";
 
 const { entries: posts } = await getLiveCollection("liveBlog");
 const sortedPosts = getSortedPosts(posts || []);
-const featuredPosts = sortedPosts
-  .filter(({ data }) => data.featured)
-  .slice(0, 4);
-const recentPosts = sortedPosts
-  .filter(({ data }) => !data.featured)
-  .slice(0, 4);
-const wordCount = post =>
-  (post.body || "").trim().split(/\s+/).filter(Boolean).length;
-const readMinutes = post => Math.max(1, Math.round(wordCount(post) / 220));
-const formatDate = value => {
-  if (!value) return "pending";
-  const date = value instanceof Date ? value : new Date(value);
-  return Number.isNaN(date.getTime())
-    ? "pending"
-    : date.toISOString().slice(0, 10);
-};
+const { featuredPosts, recentPosts } = selectHomepagePosts(sortedPosts);
+const wordCount = getPostWordCount;
+const readMinutes = getReadMinutes;
+const formatDate = formatHomepageDate;
 const jsonLd = buildWebSiteJsonLd({
   name: SITE.title,
   url: SITE.website,
@@ -166,43 +160,50 @@ const jsonLd = buildWebSiteJsonLd({
           ># EOF · last edit: 2026-06-02</span
         >
       </p>
-      <div class="block-h">
-        <h2>ls featured/ --sort=stars</h2><span class="n"
-          >{featuredPosts.length} items · author's pick</span
-        >
-      </div>
-      <div class="files">
-        {
-          featuredPosts.map(post => (
-            <a class="file" href={getPath(post.id, post.filePath)}>
-              <>
-                <div class="head">
-                  <>
-                    <span class="ext">.md</span>
+      {
+        featuredPosts.length > 0 && (
+          <>
+            <div class="block-h featured-shell-heading">
+              <h2>ls featured/ --sort=stars</h2>
+              <span class="n">
+                {featuredPosts.length} items · author's pick
+              </span>
+            </div>
+            <div
+              class="files featured-files"
+              data-featured-count={featuredPosts.length}
+            >
+              {featuredPosts.map(post => (
+                <a
+                  class="file featured-file"
+                  href={getPath(post.id, post.filePath)}
+                  aria-label={`Read featured post: ${post.data.title}`}
+                >
+                  <div class="head">
+                    <span class="ext">PINNED</span>
                     <span class="star">★</span>
                     <span>
                       {readMinutes(post)} min ·{" "}
                       {post.data.tags?.[0] ?? "field-notes"}
                     </span>
-                  </>
-                </div>
-                <div class="name">{post.id}.md</div>
-                <div class="desc">{post.data.description}</div>
-                <div class="stat">
-                  <>
+                  </div>
+                  <div class="name">{post.id}.md</div>
+                  <div class="desc">{post.data.description}</div>
+                  <div class="stat">
                     <span>
                       date <b>{formatDate(post.data.pubDatetime)}</b>
                     </span>
                     <span>
                       words <b>{wordCount(post).toLocaleString()}</b>
                     </span>
-                  </>
-                </div>
-              </>
-            </a>
-          ))
-        }
-      </div>
+                    <span class="open">open →</span>
+                  </div>
+                </a>
+              ))}
+            </div>
+          </>
+        )
+      }
       <div class="block-h">
         <h2>ls -la recent/</h2><span class="n"
           >{recentPosts.length} items · sorted by mtime</span

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -916,11 +916,15 @@ a:hover {
   font-size: 11px;
 }
 
-/* Featured cards (file-listing style) */
+/* Featured cards (pinned terminal artifact style) */
 .files {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 12px;
+}
+.featured-files {
+  gap: 16px;
+  margin-bottom: 2px;
 }
 @media (max-width: 720px) {
   .files {
@@ -944,6 +948,53 @@ a:hover {
 }
 .file:hover .name {
   color: var(--accent);
+}
+.featured-file {
+  position: relative;
+  min-height: 236px;
+  overflow: hidden;
+  border-color: color-mix(in srgb, var(--accent) 36%, var(--border));
+  border-radius: 12px;
+  padding: 18px 18px 20px;
+  background:
+    linear-gradient(135deg, rgb(255 255 255 / 0.05), transparent 42%),
+    radial-gradient(
+      circle at 18% 0%,
+      color-mix(in srgb, var(--accent) 16%, transparent),
+      transparent 34%
+    ),
+    var(--surface);
+  box-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.06),
+    0 18px 42px rgb(0 0 0 / 0.18);
+}
+.featured-file::before {
+  content: "";
+  position: absolute;
+  inset: 0 0 auto;
+  height: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--accent),
+    color-mix(in srgb, var(--warn) 82%, var(--accent)),
+    transparent
+  );
+}
+.featured-file::after {
+  content: "featured artifact";
+  position: absolute;
+  right: 16px;
+  bottom: 12px;
+  color: color-mix(in srgb, var(--muted) 28%, transparent);
+  font-family: var(--terminal-font);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+.featured-file:hover {
+  border-color: var(--accent);
+  transform: translateY(-3px);
 }
 .file .head {
   display: flex;
@@ -985,6 +1036,46 @@ a:hover {
 .file .stat b {
   color: var(--muted);
   font-weight: 500;
+}
+.featured-file .head {
+  position: relative;
+  z-index: 1;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+.featured-file .head .ext {
+  border: 1px solid color-mix(in srgb, var(--warn) 46%, transparent);
+  color: var(--warn);
+  background: color-mix(in srgb, var(--warn) 8%, transparent);
+}
+.featured-file .name {
+  position: relative;
+  z-index: 1;
+  margin-top: 16px;
+  font-size: clamp(20px, 2vw, 27px);
+  font-weight: 650;
+  letter-spacing: -0.035em;
+}
+.featured-file .desc {
+  position: relative;
+  z-index: 1;
+  max-width: 62ch;
+  margin-top: 12px;
+  color: var(--fg);
+  font-size: 14px;
+  line-height: 1.65;
+}
+.featured-file .stat {
+  position: relative;
+  z-index: 1;
+  flex-wrap: wrap;
+  align-items: center;
+  margin-top: 20px;
+}
+.featured-file .stat .open {
+  margin-left: auto;
+  color: var(--accent);
+  font-weight: 600;
 }
 
 /* Recent table */

--- a/src/utils/homepagePosts.ts
+++ b/src/utils/homepagePosts.ts
@@ -1,0 +1,32 @@
+type HomepagePost = {
+  body?: string;
+  data: {
+    featured?: boolean;
+  };
+};
+
+export function selectHomepagePosts<const Post extends HomepagePost>(
+  posts: Post[] = []
+) {
+  const featuredPosts = posts.filter(({ data }) => data.featured).slice(0, 4);
+  const recentPosts = posts.filter(({ data }) => !data.featured).slice(0, 4);
+
+  return { featuredPosts, recentPosts };
+}
+
+export function getPostWordCount(post: Pick<HomepagePost, "body">) {
+  return (post.body || "").trim().split(/\s+/).filter(Boolean).length;
+}
+
+export function getReadMinutes(post: Pick<HomepagePost, "body">) {
+  return Math.max(1, Math.round(getPostWordCount(post) / 220));
+}
+
+export function formatHomepageDate(value: Date | string | undefined | null) {
+  if (!value) return "pending";
+
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "pending"
+    : date.toISOString().slice(0, 10);
+}

--- a/tests/homepagePositioning.test.mjs
+++ b/tests/homepagePositioning.test.mjs
@@ -39,8 +39,8 @@ test("site metadata description remains approved and safe", () => {
   assert.equal(SITE.desc, expectedSiteDescription);
 });
 test("homepage keeps live post mapping and reader links present", () => {
-  assert.match(homepageSource, /featuredPosts = sortedPosts\s+\.filter/);
-  assert.match(homepageSource, /recentPosts = sortedPosts\s+\.filter/);
+  assert.match(homepageSource, /selectHomepagePosts\(sortedPosts\)/);
+  assert.match(homepageSource, /const \{ featuredPosts, recentPosts \} = selectHomepagePosts\(sortedPosts\);/);
   assert.match(homepageSource, /href="\/rss\.xml"/);
   assert.match(homepageSource, /href="\/posts\/"/);
   assert.match(homepageSource, /getPath\(post\.id, post\.filePath\)/);

--- a/tests/homepagePosts.test.mjs
+++ b/tests/homepagePosts.test.mjs
@@ -1,0 +1,98 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import {
+  formatHomepageDate,
+  getPostWordCount,
+  getReadMinutes,
+  selectHomepagePosts,
+} from "../src/utils/homepagePosts.ts";
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(error);
+  }
+}
+
+function post(id, { featured = false, body = "one two three", date = "2026-01-02T00:00:00.000Z" } = {}) {
+  return {
+    id,
+    body,
+    filePath: `src/data/blog/${id}.md`,
+    data: {
+      featured,
+      title: id,
+      description: `${id} description`,
+      pubDatetime: date,
+      tags: ["agents"],
+    },
+  };
+}
+
+const homepageSource = readFileSync(new URL("../src/pages/index.astro", import.meta.url), "utf8");
+const globalCssSource = readFileSync(new URL("../src/styles/global.css", import.meta.url), "utf8");
+
+test("selectHomepagePosts returns featured and recent paths without mixing non-featured cards", () => {
+  const posts = [post("featured-1", { featured: true }), post("recent-1"), post("featured-2", { featured: true }), post("recent-2")];
+  const { featuredPosts, recentPosts } = selectHomepagePosts(posts);
+
+  assert.deepEqual(featuredPosts.map(({ id }) => id), ["featured-1", "featured-2"]);
+  assert.deepEqual(recentPosts.map(({ id }) => id), ["recent-1", "recent-2"]);
+});
+
+test("selectHomepagePosts handles empty and all-non-featured inventories", () => {
+  assert.deepEqual(selectHomepagePosts([]), { featuredPosts: [], recentPosts: [] });
+
+  const { featuredPosts, recentPosts } = selectHomepagePosts([post("recent-1"), post("recent-2")]);
+  assert.equal(featuredPosts.length, 0);
+  assert.deepEqual(recentPosts.map(({ id }) => id), ["recent-1", "recent-2"]);
+});
+
+test("selectHomepagePosts caps homepage featured and recent lists", () => {
+  const posts = Array.from({ length: 6 }, (_, index) => post(`featured-${index}`, { featured: true })).concat(
+    Array.from({ length: 6 }, (_, index) => post(`recent-${index}`))
+  );
+  const { featuredPosts, recentPosts } = selectHomepagePosts(posts);
+
+  assert.equal(featuredPosts.length, 4);
+  assert.equal(recentPosts.length, 4);
+});
+
+test("homepage post metadata helpers handle word-count, one-minute floor, and invalid dates", () => {
+  assert.equal(getPostWordCount(post("words", { body: "  alpha beta\n gamma  " })), 3);
+  assert.equal(getReadMinutes(post("short", { body: "one two" })), 1);
+  assert.equal(getReadMinutes(post("long", { body: Array.from({ length: 440 }, () => "word").join(" ") })), 2);
+  assert.equal(formatHomepageDate("not-a-date"), "pending");
+  assert.equal(formatHomepageDate(null), "pending");
+  assert.equal(formatHomepageDate(new Date("2026-03-04T12:00:00.000Z")), "2026-03-04");
+});
+
+test("homepage renders pinned card styling only behind the featured-post guard", () => {
+  assert.match(homepageSource, /featuredPosts\.length > 0 &&/);
+  assert.match(homepageSource, /class="files featured-files"/);
+  assert.match(homepageSource, /class="file featured-file"/);
+  assert.match(homepageSource, /aria-label=\{`Read featured post: \$\{post\.data\.title\}`\}/);
+  assert.match(homepageSource, /class="open">open →<\/span>/);
+});
+
+test("featured-card CSS creates the intentional pinned treatment without changing recent rows", () => {
+  assert.match(globalCssSource, /\.featured-file\s*\{[\s\S]*min-height:\s*236px;/);
+  assert.match(globalCssSource, /\.featured-file::before\s*\{[\s\S]*height:\s*3px;/);
+  assert.match(globalCssSource, /\.featured-file::after\s*\{[\s\S]*featured artifact/);
+  assert.match(globalCssSource, /\.featured-file \.stat \.open\s*\{[\s\S]*margin-left:\s*auto;/);
+  assert.match(globalCssSource, /\.ls-row\s*\{[\s\S]*grid-template-columns:\s*24px 90px 1fr 110px 36px;/);
+});
+
+console.log(`PASS ${passed} FAIL ${failed}`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
Closes #82

Source issue: https://github.com/berryhill/bd-site/issues/82

Classification: frontend / homepage visual styling.

Prior PR audit / decision:
- Re-ran all-state PR audit before push.
- Found clean open PR #88 for head branch `feature/issue-82-pinned-post-styling` targeting `main`.
- No contaminated or closed replacement PR path needed; this PR was updated in place.
- GitHub readback: PR #88 is open, base `main`, head `feature/issue-82-pinned-post-styling`, mergeable.

Branch/base gate:
- Integration branch selected: `main` (`origin/dev` absent).
- origin/main: `6af5f53dc01f104244e32566494f30ab15057288`
- HEAD: `1457344fe4e608163d89507e49f6963e02b0850b`
- Merge base: `b318856c91858f3d161947afdef11c1d302017b3`
- Ahead/behind vs current origin/main: `3 1` (`origin/main...HEAD` left/right count). I did not merge, rebase, or force-push by guess; PR is GitHub-reported mergeable.

Summary of code changes:
- Splits featured/pinned post selection from the recent post grid via `src/utils/homepagePosts.ts`.
- Updates `src/pages/index.astro` so the pinned/featured post gets its own elevated homepage treatment instead of looking like a normal recent-card clone.
- Adds dedicated pinned-card visual styling in `src/styles/global.css`.
- Updates homepage positioning coverage and adds focused homepage post-selection tests.
- Adds `homepagePosts.test.mjs` to the scoped `pnpm test` suite in `package.json`.

Doc reconciliation:
- Checked repo docs inventory for relevant homepage/card-shell guidance.
- `docs/ai-discovery-content-slate.md` was reviewed and intentionally left unchanged because this issue is a concrete visual/frontend fix, not a strategy/doc contract change.

Destructive-diff guard output:
```text
git diff --name-status origin/main...HEAD
M	package.json
M	src/pages/index.astro
M	src/styles/global.css
A	src/utils/homepagePosts.ts
M	tests/homepagePositioning.test.mjs
A	tests/homepagePosts.test.mjs

git diff --stat origin/main...HEAD
 package.json                       |  2 +-
 src/pages/index.astro              | 85 +++++++++++++++++----------------
 src/styles/global.css              | 93 +++++++++++++++++++++++++++++++++++-
 src/utils/homepagePosts.ts         | 32 +++++++++++++
 tests/homepagePositioning.test.mjs |  4 +-
 tests/homepagePosts.test.mjs       | 98 ++++++++++++++++++++++++++++++++++++++
 6 files changed, 268 insertions(+), 46 deletions(-)
```

Destructive-diff decision: PASS. No existing source/config/onboarding files are deleted; workflow files are untouched.

Validation:
- `pnpm test` PASS
- `pnpm run lint` PASS
- `pnpm run format:check` PASS
- `pnpm run build` PASS

Local validation runtime note:
- Local readback: pnpm `11.1.3`, Node `v22.22.3`.
- CI baseline remains Node 20 / pnpm 10.11.1 per repo operating pack.

Path boundary: app/source-code-touching
