### PR TITLE
Add Google-supported crawl signal on public post publish/update

### DIFF
--- a/API.md
+++ b/API.md
@@ -174,6 +174,8 @@ Content-Type: application/json
 
 **Social preview behavior:** `ogImage` is written to frontmatter and becomes the rendered post's `og:image`, `twitter:image`, and JSON-LD image. Stored `ogImage` values may be absolute URLs, site-relative paths, or relative paths; rendered post metadata normalizes site-relative and relative values to absolute URLs using `SITE.website` without mutating the stored frontmatter value. `featured_image` is only a backward-compatible alias; `ogImage` wins when both are supplied. If no `ogImage` is stored and the post is not a draft, the site falls back to the dynamic `/posts/<slug>/index.png` image route when `SITE.dynamicOgImage` is enabled.
 
+**Public crawl signal behavior:** after a successful non-draft POST write, the API submits public crawl signals for the canonical post URL and site sitemap through IndexNow plus Google Search Console sitemap resubmission. Draft posts do not trigger crawl signals. Google Search Console submission requires a server-side `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`; `GOOGLE_SEARCH_CONSOLE_SITE_URL` and `GOOGLE_SEARCH_CONSOLE_SITEMAP_URL` are optional overrides. If the token is missing, Google submission is skipped without failing the post write.
+
 **Social preview verification:** after building or running preview, check a post page with:
 
 ```bash
@@ -247,6 +249,8 @@ Content-Type: application/json
 **Content image references:** PATCH `content` may include normal external images. Repo-backed blog visuals must be referenced as `/assets/blog/<slug>/filename.svg` or `/assets/blog/<slug>/filename.png`, include alt text plus a caption/title in Markdown, and have an existing backing file under `public/assets/blog/<slug>/`. Inline `data:image` URIs are invalid.
 
 **Social preview behavior:** PATCH follows the same `ogImage` / `featured_image` precedence as create: `ogImage` is stored in frontmatter when supplied, `featured_image` is only a backward-compatible alias, and `ogImage` wins when both are supplied. Stored `ogImage` values may be absolute URLs, site-relative paths, or relative paths; rendered post metadata normalizes site-relative and relative values to absolute URLs using `SITE.website` without mutating the stored frontmatter value. Updated post pages can be verified with `pnpm run check:social-preview -- http://localhost:4321/posts/<slug>/` after building or running preview.
+
+**Public crawl signal behavior:** after a successful PATCH write, if the resulting post is not a draft, the API submits public crawl signals for the canonical post URL and site sitemap through IndexNow plus Google Search Console sitemap resubmission. Draft updates do not trigger crawl signals. Google Search Console submission requires a server-side `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`; `GOOGLE_SEARCH_CONSOLE_SITE_URL` and `GOOGLE_SEARCH_CONSOLE_SITEMAP_URL` are optional overrides. If the token is missing, Google submission is skipped without failing the post write.
 
 **Response (200 OK):**
 ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,8 @@ pnpm run format:check # Check formatting without writing
   - Site OG image: `/og.png.ts`
 - **URL Normalization**: [src/utils/url.ts](src/utils/url.ts) - Normalizes `SITE.website`, site-relative paths, post URLs, and post asset URLs to absolute URLs for post metadata and custom sitemap routes
 - **Crawl Signals**: [src/utils/crawlSignals.ts](src/utils/crawlSignals.ts) - Shared source for canonical sitemap path, robots.txt crawler groups, generated asset disallow policy, and Layout sitemap href
+- **Public Post Crawl Signals**: [src/utils/publicPostCrawlSignals.ts](src/utils/publicPostCrawlSignals.ts) - Coordinates IndexNow plus Google Search Console sitemap submission for public posts
+- **Google Search Console Submission**: [src/utils/googleSearchConsole.ts](src/utils/googleSearchConsole.ts) - Submits `/sitemap.xml` to Google Search Console using optional server-side environment configuration
 - **Static Sitemap**: [src/utils/staticSitemap.ts](src/utils/staticSitemap.ts) - Shared source for static sitemap page selection and XML generation
 - **Tag Management**: `getUniqueTags.ts`, `getPostsByTag.ts` for tag-based filtering
 - **Slugification**: `slugify.ts` uses lodash.kebabcase for URL-friendly slugs
@@ -124,6 +126,7 @@ Search is powered by Pagefind, which indexes the built site and provides client-
 - The project uses pnpm as the package manager
 - Blog posts with filenames starting with `_` are ignored by the glob loader pattern
 - Durable local blog visuals must use normal Markdown image syntax with alt text and caption/title; do not inline `data:image` URIs.
+- POST/PATCH `/api/posts` trigger crawl signals only for non-draft posts after successful file writes. IndexNow submits the post URL immediately; Google Search Console sitemap submission is best-effort and skipped when credentials are missing.
 - Posts are timezone-aware; global timezone is set in `SITE.timezone` (IANA format), individual posts can override with frontmatter `timezone`
 - The edit post feature links to a GitHub repository URL (configurable in `SITE.editPost`)
 - Archives page visibility is controlled by `SITE.showArchives` in the sitemap filter

--- a/LLM_CRAWL_MANIFEST.md
+++ b/LLM_CRAWL_MANIFEST.md
@@ -16,12 +16,16 @@
 - **URL normalization**: Static page `<loc>` values in `/sitemap-static.xml` and post `<loc>` values in `/sitemap-posts.xml` are normalized through the shared URL helper using `SITE.website`.
 - **Update Frequency**: Real-time (generated on-demand)
 - **Submission Status**:
-  - Google Search Console: Pending
+  - Google Search Console: Sitemap resubmission is implemented for public post create/update when `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN` is configured; operational Search Console property/token provisioning remains environment-dependent unless separately verified.
   - Bing Webmaster Tools: Pending
 - **IndexNow**: ✅ **IMPLEMENTED**
   - API Key: Hosted at `/a63643bb50ffbee1ac79fcfe60003c1dc912bdee3803a9308fa313f06024d2c6.txt`
   - Auto-submits to Bing, Yandex, Naver, Seznam, Yep on post create/update
   - Supports bulk submission (up to 10,000 URLs)
+- **Google Search Console crawl signal**: ✅ **IMPLEMENTED**
+  - Supported signal is Search Console sitemap resubmission, not the unsupported per-URL Google Indexing API for ordinary blog posts.
+  - Submits the canonical `/sitemap.xml` after non-draft post POST/PATCH when server-side Google credentials are configured.
+  - Missing Google configuration is skipped safely and does not fail the post write.
 
 ### ✅ **FIXED: Blog Posts Now in Sitemap!**
 Previously, only 6 static pages were included. Now public blog posts that pass the shared filter are discoverable by search engines and LLM crawlers, excluding drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.
@@ -153,6 +157,7 @@ All structured data uses [Schema.org](https://schema.org) JSON-LD. The global `B
 4. llms.txt manifest endpoint at `/llms.txt` (2026-06-21, PR #35)
 5. Issue #58 crawl-signal reconciliation (2026-07-03): canonical `/sitemap.xml` signals in robots/layout/llms/check script, robots asset/index noise reduction, static sitemap redirect exclusion, and search visibility check alignment
 6. Issue #59 public-post filtering reconciliation (2026-07-03): RSS, Atom, `/llms.txt`, and `/sitemap-posts.xml` share `getSortedPosts`/`getPublicPosts` so machine-readable surfaces expose the same public corpus.
+7. Issue #97 public-post crawl signals (2026-07-08): public post create/update now sends IndexNow and Google Search Console sitemap crawl signals through shared `submitPublicPostCrawlSignals`, skipping drafts and missing Google config safely.
 
 ### ⚠️ Production Deployment Note (2026-06-21)
 
@@ -172,7 +177,7 @@ curl -si https://berryhill.dev/llms.txt | head -5
 
 ### 🔄 In Progress:
 1. Verify `/llms.txt` is live in production after deployment
-2. Submit sitemap to Google Search Console
+2. Configure/verify Google Search Console credentials and property in production
 3. Submit sitemap to Bing Webmaster Tools
 
 ### ✅ Phase 5 (2026-06-25, PR pending):
@@ -184,7 +189,7 @@ curl -si https://berryhill.dev/llms.txt | head -5
 ### 📋 Planned:
 1. Add FAQPage schema if FAQ content is created
 2. Monitor crawler activity in server logs
-3. Submit sitemap to Google Search Console
+3. Configure/verify Search Console credentials/property in production
 4. Submit sitemap to Bing Webmaster Tools
 
 ## Verification Script
@@ -220,6 +225,9 @@ Pagefind note: `/search` remains a real crawlable page. Generated `/pagefind/` i
 
 ## Changelog
 
+### 2026-07-08
+- ✅ **Public Post Crawl Signals** (Issue #97): Public post create/update now sends IndexNow and Google Search Console sitemap crawl signals through shared `submitPublicPostCrawlSignals`, skipping drafts and missing Google config safely. Google uses supported Search Console sitemap resubmission for the canonical `/sitemap.xml`; production credentials/property remain configuration-dependent unless separately verified.
+
 ### 2026-07-03
 - ✅ **Public Post Filtering Reconciliation** (Issue #59): RSS, Atom, `/llms.txt`, and `/sitemap-posts.xml` now share public-post filtering for drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.
 - ✅ **Static Sitemap, Robots, and Search Indexing Signals** (Issue #58): Canonical `/sitemap.xml` signals now flow through robots.txt, layout metadata, `/llms.txt`, and `check:search-visibility`; `/sitemap-static.xml` excludes redirect-only paths such as `/sitemap-index.xml`; robots.txt keeps the AI crawler allowlist while disallowing generated asset/index noise; shared `crawlSignals` and `staticSitemap` utilities and tests cover the policy.
@@ -252,4 +260,4 @@ Pagefind note: `/search` remains a real crawlable page. Generated `/pagefind/` i
 - ✅ Created LLM Crawl Manifest documentation
 
 ## Last Updated
-2026-07-03
+2026-07-08

--- a/README.md
+++ b/README.md
@@ -165,6 +165,11 @@ Optional environment variables:
 # Google Search Console verification
 PUBLIC_GOOGLE_SITE_VERIFICATION=your-verification-code
 
+# Optional server-side Google Search Console crawl signal submission
+GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN=secret-access-token
+GOOGLE_SEARCH_CONSOLE_SITE_URL=https://berryhill.dev/
+GOOGLE_SEARCH_CONSOLE_SITEMAP_URL=https://berryhill.dev/sitemap.xml
+
 # Server configuration (defaults shown)
 PORT=80
 HOST=0.0.0.0
@@ -174,6 +179,8 @@ NODE_ENV=production
 ## 📝 Blog Content Management
 
 Blog posts are stored as Markdown files in `src/data/blog/`. In production, the posts directory is mounted as a PersistentVolume, allowing content updates without rebuilding the container.
+
+API-created or API-updated non-draft posts trigger public crawl signals after the Markdown write: IndexNow performs immediate URL submission, and Google uses supported Search Console sitemap resubmission. Draft posts are skipped.
 
 Durable local blog visuals belong under `public/assets/blog/<post-slug>/` and should be referenced from Markdown as `/assets/blog/<post-slug>/filename.svg` or `/assets/blog/<post-slug>/filename.png`. Use normal Markdown image syntax with useful alt text and a caption/title; inline `data:image` URIs are rejected.
 
@@ -222,7 +229,7 @@ GitHub Actions workflow (`.github/workflows/deploy.yaml`):
 - Interactive pillar modals
 - Dark/light mode toggle
 - Fuzzy search with Pagefind (`/search`; generated `/pagefind/` assets are not crawler-facing content)
-- RSS feed plus canonical `/sitemap.xml` crawler surface (`/sitemap-index.xml` redirects only for compatibility)
+- RSS feed plus canonical `/sitemap.xml` crawler surface (`/sitemap-index.xml` redirects only for compatibility), with public-post crawl signal submission on API publish/update; Google Search Console submission is best-effort and configuration-dependent
 - Dynamic OG image generation
 
 ## 📜 License

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/homepagePosts.test.mjs && node tests/homepageFleet.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/googleSearchConsole.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/homepagePosts.test.mjs && node tests/homepageFleet.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:seo-crawl-surface": "node scripts/checkSeoCrawlSurface.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -3,8 +3,8 @@ import { writeFile, readFile, readdir, unlink } from "fs/promises";
 import { join } from "path";
 import { slugifyStr } from "@/utils/slugify";
 import matter from "gray-matter";
-import { submitToIndexNow } from "@/utils/indexnow";
 import { SITE } from "@/config";
+import { submitPublicPostCrawlSignals } from "@/utils/publicPostCrawlSignals";
 import { requireApiKey } from "@/utils/apiAuth";
 import { validateBlogVisualAssets } from "@/utils/blogVisualAssets";
 
@@ -266,10 +266,10 @@ export const POST: APIRoute = async context => {
     const filePath = join(process.cwd(), "src", "data", "blog", filename);
     await writeFile(filePath, fileContent, "utf-8");
 
-    // Submit to IndexNow if not a draft
+    // Submit public crawl signals if not a draft
     if (!draft) {
       const postUrl = `${SITE.website}posts/${slug}/`;
-      await submitToIndexNow(postUrl);
+      await submitPublicPostCrawlSignals(postUrl);
     }
 
     return new Response(
@@ -456,11 +456,11 @@ export const PATCH: APIRoute = async context => {
     // Write back to file
     await writeFile(filePath, updatedFile, "utf-8");
 
-    // Submit to IndexNow if not a draft
+    // Submit public crawl signals if not a draft
     const isDraft = draft !== undefined ? draft : frontmatterData.draft;
     if (!isDraft) {
       const postUrl = `${SITE.website}posts/${slug}/`;
-      await submitToIndexNow(postUrl);
+      await submitPublicPostCrawlSignals(postUrl);
     }
 
     return new Response(

--- a/src/utils/googleSearchConsole.ts
+++ b/src/utils/googleSearchConsole.ts
@@ -1,0 +1,89 @@
+/* eslint-disable no-console */
+
+declare const process: {
+  env: Record<string, string | undefined>;
+};
+
+export interface GoogleSearchConsoleSubmitResult {
+  ok: boolean;
+  skipped?: boolean;
+  reason?: string;
+  status?: number;
+}
+
+const GOOGLE_SEARCH_CONSOLE_SITEMAP_ENDPOINT =
+  "https://www.googleapis.com/webmasters/v3/sites";
+const DEFAULT_SITE = "https://berryhill.dev/";
+
+const getEnv = (key: string): string | undefined => {
+  const value = process.env[key]?.trim();
+  return value ? value : undefined;
+};
+
+const normalizeSiteUrl = (siteUrl: string): string => {
+  if (siteUrl.startsWith("sc-domain:")) return siteUrl;
+  return new URL(siteUrl).toString();
+};
+
+const defaultSitemapUrl = (): string =>
+  new URL("/sitemap.xml", DEFAULT_SITE).toString();
+
+export async function submitSitemapToGoogleSearchConsole(options?: {
+  sitemapUrl?: string;
+  siteUrl?: string;
+  accessToken?: string;
+}): Promise<GoogleSearchConsoleSubmitResult> {
+  const accessToken =
+    options?.accessToken ?? getEnv("GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN");
+
+  if (!accessToken) {
+    return {
+      ok: false,
+      skipped: true,
+      reason: "missing_config: GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN",
+    };
+  }
+
+  const siteUrl =
+    options?.siteUrl ??
+    getEnv("GOOGLE_SEARCH_CONSOLE_SITE_URL") ??
+    DEFAULT_SITE;
+  const sitemapUrl =
+    options?.sitemapUrl ??
+    getEnv("GOOGLE_SEARCH_CONSOLE_SITEMAP_URL") ??
+    defaultSitemapUrl();
+
+  try {
+    const endpoint = `${GOOGLE_SEARCH_CONSOLE_SITEMAP_ENDPOINT}/${encodeURIComponent(normalizeSiteUrl(siteUrl))}/sitemaps/${encodeURIComponent(new URL(sitemapUrl).toString())}`;
+    const response = await fetch(endpoint, {
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!response.ok) {
+      console.warn("Google Search Console sitemap submission failed", {
+        status: response.status,
+        sitemapUrl,
+        siteUrl,
+      });
+    }
+
+    return {
+      ok: response.ok,
+      status: response.status,
+    };
+  } catch (error) {
+    console.warn("Google Search Console sitemap submission errored", {
+      error: error instanceof Error ? error.message : String(error),
+      sitemapUrl,
+      siteUrl,
+    });
+
+    return {
+      ok: false,
+      reason: error instanceof Error ? error.message : "unknown_error",
+    };
+  }
+}

--- a/src/utils/publicPostCrawlSignals.ts
+++ b/src/utils/publicPostCrawlSignals.ts
@@ -1,0 +1,46 @@
+import { submitSitemapToGoogleSearchConsole } from "./googleSearchConsole";
+import { submitToIndexNow } from "./indexnow";
+
+export interface PublicPostCrawlSignalResult {
+  ok: boolean;
+  skipped?: boolean;
+  reason?: string;
+  indexNow?: boolean;
+  google?: Awaited<ReturnType<typeof submitSitemapToGoogleSearchConsole>>;
+}
+
+interface PublicPostCrawlSignalDeps {
+  submitIndexNow?: typeof submitToIndexNow;
+  submitGoogleSitemap?: typeof submitSitemapToGoogleSearchConsole;
+}
+
+export async function submitPublicPostCrawlSignals(
+  postUrl: string,
+  options?: {
+    isDraft?: boolean;
+    deps?: PublicPostCrawlSignalDeps;
+  }
+): Promise<PublicPostCrawlSignalResult> {
+  if (options?.isDraft) {
+    return {
+      ok: true,
+      skipped: true,
+      reason: "draft",
+    };
+  }
+
+  const submitIndexNow = options?.deps?.submitIndexNow ?? submitToIndexNow;
+  const submitGoogleSitemap =
+    options?.deps?.submitGoogleSitemap ?? submitSitemapToGoogleSearchConsole;
+
+  const [indexNow, google] = await Promise.all([
+    submitIndexNow(postUrl),
+    submitGoogleSitemap(),
+  ]);
+
+  return {
+    ok: indexNow && (google.ok || google.skipped === true),
+    indexNow,
+    google,
+  };
+}

--- a/tests/googleSearchConsole.test.mjs
+++ b/tests/googleSearchConsole.test.mjs
@@ -1,0 +1,138 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { submitSitemapToGoogleSearchConsole } from "../src/utils/googleSearchConsole.ts";
+
+let passed = 0;
+let failed = 0;
+
+async function run() {
+  const tests = [];
+  const add = (name, fn) => {
+    tests.push([name, fn]);
+  };
+
+  add("Google Search Console submission skips cleanly when bearer token is missing", async () => {
+    const originalToken = process.env.GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN;
+    const originalFetch = globalThis.fetch;
+    delete process.env.GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN;
+    let fetchCalled = false;
+    globalThis.fetch = async () => {
+      fetchCalled = true;
+      return new Response(null, { status: 204 });
+    };
+
+    try {
+      const result = await submitSitemapToGoogleSearchConsole();
+      assert.deepEqual(result, {
+        ok: false,
+        skipped: true,
+        reason: "missing_config: GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN",
+      });
+      assert.equal(fetchCalled, false);
+    } finally {
+      if (originalToken === undefined) {
+        delete process.env.GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN;
+      } else {
+        process.env.GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN = originalToken;
+      }
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  add("Google Search Console submission uses supported sitemap endpoint with server bearer token", async () => {
+    const originalFetch = globalThis.fetch;
+    let requestUrl = "";
+    let requestInit;
+    globalThis.fetch = async (url, init) => {
+      requestUrl = String(url);
+      requestInit = init;
+      return new Response(null, { status: 204 });
+    };
+
+    try {
+      const result = await submitSitemapToGoogleSearchConsole({
+        accessToken: "test-token",
+        siteUrl: "https://berryhill.dev/",
+        sitemapUrl: "https://berryhill.dev/sitemap.xml",
+      });
+
+      assert.deepEqual(result, { ok: true, status: 204 });
+      assert.equal(requestInit.method, "PUT");
+      assert.equal(requestInit.headers.Authorization, "Bearer test-token");
+      assert.match(
+        requestUrl,
+        /^https:\/\/www\.googleapis\.com\/webmasters\/v3\/sites\//
+      );
+      assert.match(requestUrl, /sitemaps\//);
+      assert.doesNotMatch(requestUrl, /indexing\/v3/);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  add("Google Search Console API failure is observable and non-throwing", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalWarn = console.warn;
+    let warned = false;
+    globalThis.fetch = async () => new Response("nope", { status: 403 });
+    console.warn = () => {
+      warned = true;
+    };
+
+    try {
+      const result = await submitSitemapToGoogleSearchConsole({
+        accessToken: "test-token",
+      });
+
+      assert.deepEqual(result, { ok: false, status: 403 });
+      assert.equal(warned, true);
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.warn = originalWarn;
+    }
+  });
+
+  add("public post crawl utility attempts IndexNow and Google but skips drafts", () => {
+    const source = readFileSync(
+      new URL("../src/utils/publicPostCrawlSignals.ts", import.meta.url),
+      "utf8"
+    );
+
+    assert.match(source, /if \(options\?\.isDraft\) \{/);
+    assert.match(source, /reason: "draft"/);
+    assert.match(source, /Promise\.all\(\[/);
+    assert.match(source, /submitIndexNow\(postUrl\)/);
+    assert.match(source, /submitGoogleSitemap\(\)/);
+  });
+
+  add("posts API only emits public crawl signals inside non-draft create/update branches", () => {
+    const source = readFileSync(
+      new URL("../src/pages/api/posts.ts", import.meta.url),
+      "utf8"
+    );
+
+    assert.match(source, /submitPublicPostCrawlSignals\(postUrl\)/);
+    assert.match(source, /if \(!draft\) \{[\s\S]*?submitPublicPostCrawlSignals\(postUrl\);[\s\S]*?\}/);
+    assert.match(source, /const isDraft = draft !== undefined \? draft : frontmatterData\.draft;[\s\S]*?if \(!isDraft\) \{[\s\S]*?submitPublicPostCrawlSignals\(postUrl\);[\s\S]*?\}/);
+  });
+
+  for (const [name, fn] of tests) {
+    try {
+      await fn();
+      passed += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(`FAIL ${name}`);
+      console.error(error);
+    }
+  }
+
+  console.log(`PASS ${passed} FAIL ${failed}`);
+
+  if (failed > 0) {
+    process.exitCode = 1;
+  }
+}
+
+await run();


### PR DESCRIPTION
## Source issue
Closes #97

## Classification / path boundary
- Classification: app/source-code-touching plus docs reconciliation.
- Path boundary: app/source-code-touching; docs touched only to reconcile the new public crawl-signal behavior.
- Scope: Google-supported crawl signal for public post publish/update using Search Console sitemap resubmission, not the Google Indexing API.

## Prior PR audit / decision
- Audited all PR states for head branch `feature/issue-97-google-crawl-signal`: none found.
- Audited all PR states for task branch `task-t_836dc0e-97`: none found.
- Decision: open a clean new PR from `feature/issue-97-google-crawl-signal` to `main`.
- Branch/base readback before push: integration branch `main`; `origin/main` at `224f86a`; feature HEAD at `8d36539`; `origin/main...HEAD` reported 1 commit behind and 2 commits ahead. No rebase/merge was performed by guess.

## Code changes
- Added `src/utils/googleSearchConsole.ts` to submit the canonical sitemap to the supported Google Search Console sitemap endpoint using a server-side bearer token.
- Added `src/utils/publicPostCrawlSignals.ts` so public post publish/update emits IndexNow plus Google sitemap-resubmission signals through one utility.
- Updated `src/pages/api/posts.ts` so successful non-draft POST/PATCH writes submit public crawl signals after the Markdown write; draft posts skip the signals.
- Updated `package.json` test script to include the new Google Search Console regression test.
- Added `tests/googleSearchConsole.test.mjs` covering missing-token skip behavior, supported endpoint shape, non-throwing API failure behavior, draft skipping, and non-draft POST/PATCH wiring.

## Doc reconciliation actions
- Updated `API.md` Create Post and Update Post sections with public crawl-signal behavior, including non-draft-only behavior, IndexNow plus Google Search Console sitemap resubmission, optional env overrides, and missing-token skip behavior.
- Updated `README.md` content-management/features notes to mention API-created or API-updated non-draft posts submit IndexNow plus Google Search Console sitemap resubmission.
- Updated `CLAUDE.md` key utilities / important notes to include the new public post crawl-signal utility and behavior.
- Updated `LLM_CRAWL_MANIFEST.md` to document Google Search Console sitemap resubmission as a submitter-facing signal and preserve `/sitemap.xml` as the canonical crawler-facing surface.
- Left `docs/ai-discovery-content-slate.md` unchanged because it was not relevant to this issue.

## Destructive-diff guard
- `git diff --name-status origin/main...HEAD`: 9 intended files changed; no deletions.
- `git diff --stat origin/main...HEAD`: 306 insertions, 11 deletions.
- `git diff --name-status --diff-filter=D origin/main...HEAD | wc -l`: 0.
- `.github/workflows/*` touched: no.

## Validation
- `pnpm test` passed.
- `pnpm run lint` passed.
- `pnpm run format:check` passed.
- `pnpm run build` passed.

## Notes for reviewers
- Google submission is best-effort/configuration-dependent. Without `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`, the Google step returns a skipped result and does not fail the post write.
- The implementation deliberately uses Search Console sitemap resubmission because that is the Google-supported path for normal blog/article URLs; it does not use the Google Indexing API.
