### PR TITLE
Add Yahoo post-publish indexing signal

### DIFF
--- a/API.md
+++ b/API.md
@@ -174,7 +174,7 @@ Content-Type: application/json
 
 **Social preview behavior:** `ogImage` is written to frontmatter and becomes the rendered post's `og:image`, `twitter:image`, and JSON-LD image. Stored `ogImage` values may be absolute URLs, site-relative paths, or relative paths; rendered post metadata normalizes site-relative and relative values to absolute URLs using `SITE.website` without mutating the stored frontmatter value. `featured_image` is only a backward-compatible alias; `ogImage` wins when both are supplied. If no `ogImage` is stored and the post is not a draft, the site falls back to the dynamic `/posts/<slug>/index.png` image route when `SITE.dynamicOgImage` is enabled.
 
-**Public crawl signal behavior:** after a successful non-draft POST write, the API submits public crawl signals for the canonical post URL and site sitemap through IndexNow plus Google Search Console sitemap resubmission. Draft posts do not trigger crawl signals. Google Search Console submission requires a server-side `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`; `GOOGLE_SEARCH_CONSOLE_SITE_URL` and `GOOGLE_SEARCH_CONSOLE_SITEMAP_URL` are optional overrides. If the token is missing, Google submission is skipped without failing the post write.
+**Public crawl signal behavior:** after a successful non-draft POST write, the API submits public crawl signals for the canonical post URL and site sitemap. The response includes `crawlSignals` evidence with `indexNow`, `google`, and `yahoo` fields: IndexNow submits the post URL, Google Search Console performs supported sitemap resubmission, and Yahoo evidence records crawl discovery through Bing IndexNow / Yahoo Slurp plus sitemap and robots access. Yahoo is not a standalone Yahoo-owned submit endpoint and does not guarantee indexing. Draft posts skip crawl signals. Google Search Console submission requires a server-side `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`; `GOOGLE_SEARCH_CONSOLE_SITE_URL` and `GOOGLE_SEARCH_CONSOLE_SITEMAP_URL` are optional overrides. If the token is missing, Google submission is skipped without failing the post write.
 
 **Social preview verification:** after building or running preview, check a post page with:
 
@@ -190,9 +190,30 @@ The command verifies `<title>`, meta description, Open Graph title/description/i
   "success": true,
   "message": "Post created successfully",
   "slug": "my-new-post",
-  "filename": "my-new-post.md"
+  "filename": "my-new-post.md",
+  "crawlSignals": {
+    "ok": true,
+    "indexNow": true,
+    "google": {
+      "ok": true,
+      "skipped": false
+    },
+    "yahoo": {
+      "ok": true,
+      "route": "bing_indexnow_yahoo_crawl_discovery",
+      "searchEngine": "yahoo",
+      "via": "bing_webmaster_tools_indexnow",
+      "crawler": "Yahoo Slurp",
+      "endpoint": "https://www.bing.com/indexnow",
+      "robotsTxt": "/robots.txt",
+      "guaranteedIndexing": false,
+      "indexNowSubmitted": true
+    }
+  }
 }
 ```
+
+`crawlSignals` appears only for non-draft writes. The `yahoo` object is honest discovery evidence through Bing IndexNow / Yahoo Slurp and sitemap/robots visibility; it is not proof of guaranteed Yahoo indexing.
 
 ## 5. Update Post
 
@@ -250,7 +271,7 @@ Content-Type: application/json
 
 **Social preview behavior:** PATCH follows the same `ogImage` / `featured_image` precedence as create: `ogImage` is stored in frontmatter when supplied, `featured_image` is only a backward-compatible alias, and `ogImage` wins when both are supplied. Stored `ogImage` values may be absolute URLs, site-relative paths, or relative paths; rendered post metadata normalizes site-relative and relative values to absolute URLs using `SITE.website` without mutating the stored frontmatter value. Updated post pages can be verified with `pnpm run check:social-preview -- http://localhost:4321/posts/<slug>/` after building or running preview.
 
-**Public crawl signal behavior:** after a successful PATCH write, if the resulting post is not a draft, the API submits public crawl signals for the canonical post URL and site sitemap through IndexNow plus Google Search Console sitemap resubmission. Draft updates do not trigger crawl signals. Google Search Console submission requires a server-side `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`; `GOOGLE_SEARCH_CONSOLE_SITE_URL` and `GOOGLE_SEARCH_CONSOLE_SITEMAP_URL` are optional overrides. If the token is missing, Google submission is skipped without failing the post write.
+**Public crawl signal behavior:** after a successful PATCH write, if the resulting post is not a draft, the API submits public crawl signals for the canonical post URL and site sitemap. The response includes `crawlSignals` evidence with `indexNow`, `google`, and `yahoo` fields: IndexNow submits the post URL, Google Search Console performs supported sitemap resubmission, and Yahoo evidence records crawl discovery through Bing IndexNow / Yahoo Slurp plus sitemap and robots access. Yahoo is not a standalone Yahoo-owned submit endpoint and does not guarantee indexing. Draft updates skip crawl signals. Google Search Console submission requires a server-side `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN`; `GOOGLE_SEARCH_CONSOLE_SITE_URL` and `GOOGLE_SEARCH_CONSOLE_SITEMAP_URL` are optional overrides. If the token is missing, Google submission is skipped without failing the post write.
 
 **Response (200 OK):**
 ```json
@@ -261,9 +282,30 @@ Content-Type: application/json
   "updated": {
     "featured": true,
     "draft": false
+  },
+  "crawlSignals": {
+    "ok": true,
+    "indexNow": true,
+    "google": {
+      "ok": true,
+      "skipped": false
+    },
+    "yahoo": {
+      "ok": true,
+      "route": "bing_indexnow_yahoo_crawl_discovery",
+      "searchEngine": "yahoo",
+      "via": "bing_webmaster_tools_indexnow",
+      "crawler": "Yahoo Slurp",
+      "endpoint": "https://www.bing.com/indexnow",
+      "robotsTxt": "/robots.txt",
+      "guaranteedIndexing": false,
+      "indexNowSubmitted": true
+    }
   }
 }
 ```
+
+`crawlSignals` appears only when the resulting post is non-draft. The `yahoo` object is honest discovery evidence through Bing IndexNow / Yahoo Slurp and sitemap/robots visibility; it is not proof of guaranteed Yahoo indexing.
 
 ## 6. Delete Post
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ pnpm run format:check # Check formatting without writing
   - Site OG image: `/og.png.ts`
 - **URL Normalization**: [src/utils/url.ts](src/utils/url.ts) - Normalizes `SITE.website`, site-relative paths, post URLs, and post asset URLs to absolute URLs for post metadata and custom sitemap routes
 - **Crawl Signals**: [src/utils/crawlSignals.ts](src/utils/crawlSignals.ts) - Shared source for canonical sitemap path, robots.txt crawler groups, generated asset disallow policy, and Layout sitemap href
-- **Public Post Crawl Signals**: [src/utils/publicPostCrawlSignals.ts](src/utils/publicPostCrawlSignals.ts) - Coordinates IndexNow plus Google Search Console sitemap submission for public posts
+- **Public Post Crawl Signals**: [src/utils/publicPostCrawlSignals.ts](src/utils/publicPostCrawlSignals.ts) - Coordinates IndexNow plus Google Search Console sitemap submission for public posts and returns Yahoo-specific discovery evidence via Bing IndexNow / Yahoo Slurp; Yahoo evidence is not a standalone Yahoo-owned submit endpoint and does not guarantee indexing
 - **Google Search Console Submission**: [src/utils/googleSearchConsole.ts](src/utils/googleSearchConsole.ts) - Submits `/sitemap.xml` to Google Search Console using optional server-side environment configuration
 - **Static Sitemap**: [src/utils/staticSitemap.ts](src/utils/staticSitemap.ts) - Shared source for static sitemap page selection and XML generation
 - **Tag Management**: `getUniqueTags.ts`, `getPostsByTag.ts` for tag-based filtering
@@ -126,7 +126,7 @@ Search is powered by Pagefind, which indexes the built site and provides client-
 - The project uses pnpm as the package manager
 - Blog posts with filenames starting with `_` are ignored by the glob loader pattern
 - Durable local blog visuals must use normal Markdown image syntax with alt text and caption/title; do not inline `data:image` URIs.
-- POST/PATCH `/api/posts` trigger crawl signals only for non-draft posts after successful file writes. IndexNow submits the post URL immediately; Google Search Console sitemap submission is best-effort and skipped when credentials are missing.
+- POST/PATCH `/api/posts` include `crawlSignals` responses only for non-draft posts after successful file writes. IndexNow submits the post URL immediately; Google Search Console sitemap submission is best-effort and skipped when credentials are missing; Yahoo-specific evidence is discovery via Bing IndexNow / Yahoo Slurp, not guaranteed Yahoo indexing.
 - Posts are timezone-aware; global timezone is set in `SITE.timezone` (IANA format), individual posts can override with frontmatter `timezone`
 - The edit post feature links to a GitHub repository URL (configurable in `SITE.editPost`)
 - Archives page visibility is controlled by `SITE.showArchives` in the sitemap filter

--- a/LLM_CRAWL_MANIFEST.md
+++ b/LLM_CRAWL_MANIFEST.md
@@ -17,11 +17,12 @@
 - **Update Frequency**: Real-time (generated on-demand)
 - **Submission Status**:
   - Google Search Console: Sitemap resubmission is implemented for public post create/update when `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN` is configured; operational Search Console property/token provisioning remains environment-dependent unless separately verified.
-  - Bing Webmaster Tools: Pending
+  - Bing Webmaster Tools: IndexNow post URL submission is implemented and now also provides Yahoo crawl-discovery evidence via Bing IndexNow / Yahoo Slurp; direct Bing Webmaster Tools sitemap submission remains pending.
 - **IndexNow**: ✅ **IMPLEMENTED**
   - API Key: Hosted at `/a63643bb50ffbee1ac79fcfe60003c1dc912bdee3803a9308fa313f06024d2c6.txt`
-  - Auto-submits to Bing, Yandex, Naver, Seznam, Yep on post create/update
+  - Auto-submits to Bing, Yandex, Naver, Seznam, Yep on non-draft post create/update
   - Supports bulk submission (up to 10,000 URLs)
+  - Yahoo crawl-discovery evidence is returned via Bing IndexNow / Yahoo Slurp plus sitemap and robots visibility. This is not a standalone Yahoo-owned submit endpoint and does not guarantee Yahoo indexing.
 - **Google Search Console crawl signal**: ✅ **IMPLEMENTED**
   - Supported signal is Search Console sitemap resubmission, not the unsupported per-URL Google Indexing API for ordinary blog posts.
   - Submits the canonical `/sitemap.xml` after non-draft post POST/PATCH when server-side Google credentials are configured.
@@ -158,6 +159,7 @@ All structured data uses [Schema.org](https://schema.org) JSON-LD. The global `B
 5. Issue #58 crawl-signal reconciliation (2026-07-03): canonical `/sitemap.xml` signals in robots/layout/llms/check script, robots asset/index noise reduction, static sitemap redirect exclusion, and search visibility check alignment
 6. Issue #59 public-post filtering reconciliation (2026-07-03): RSS, Atom, `/llms.txt`, and `/sitemap-posts.xml` share `getSortedPosts`/`getPublicPosts` so machine-readable surfaces expose the same public corpus.
 7. Issue #97 public-post crawl signals (2026-07-08): public post create/update now sends IndexNow and Google Search Console sitemap crawl signals through shared `submitPublicPostCrawlSignals`, skipping drafts and missing Google config safely.
+8. Issue #102 Yahoo crawl-discovery evidence (2026-07-08): non-draft post create/update responses include Yahoo-specific discovery evidence via Bing IndexNow / Yahoo Slurp, sitemap, and robots visibility. This is not a standalone Yahoo-owned submit endpoint and does not guarantee indexing.
 
 ### ⚠️ Production Deployment Note (2026-06-21)
 
@@ -178,7 +180,7 @@ curl -si https://berryhill.dev/llms.txt | head -5
 ### 🔄 In Progress:
 1. Verify `/llms.txt` is live in production after deployment
 2. Configure/verify Google Search Console credentials and property in production
-3. Submit sitemap to Bing Webmaster Tools
+3. Submit sitemap directly in Bing Webmaster Tools; IndexNow URL submission and Yahoo discovery evidence via Bing IndexNow / Yahoo Slurp are implemented, but direct webmaster sitemap submission remains pending
 
 ### ✅ Phase 5 (2026-06-25, PR pending):
 1. ✅ Added `scripts/checkSearchVisibility.mjs` verification harness
@@ -190,7 +192,7 @@ curl -si https://berryhill.dev/llms.txt | head -5
 1. Add FAQPage schema if FAQ content is created
 2. Monitor crawler activity in server logs
 3. Configure/verify Search Console credentials/property in production
-4. Submit sitemap to Bing Webmaster Tools
+4. Submit sitemap directly in Bing Webmaster Tools; do not treat the implemented Yahoo discovery evidence as guaranteed indexing
 
 ## Verification Script
 
@@ -227,6 +229,7 @@ Pagefind note: `/search` remains a real crawlable page. Generated `/pagefind/` i
 
 ### 2026-07-08
 - ✅ **Public Post Crawl Signals** (Issue #97): Public post create/update now sends IndexNow and Google Search Console sitemap crawl signals through shared `submitPublicPostCrawlSignals`, skipping drafts and missing Google config safely. Google uses supported Search Console sitemap resubmission for the canonical `/sitemap.xml`; production credentials/property remain configuration-dependent unless separately verified.
+- ✅ **Yahoo Crawl-Discovery Evidence** (Issue #102): Non-draft post create/update responses now include Yahoo-specific evidence from `submitPublicPostCrawlSignals` via Bing IndexNow / Yahoo Slurp plus sitemap and robots visibility. This is honest discovery evidence, not a standalone Yahoo-owned submit endpoint and not guaranteed indexing. No Yahoo-specific environment variable, secret, deploy value, or Helm value is required.
 
 ### 2026-07-03
 - ✅ **Public Post Filtering Reconciliation** (Issue #59): RSS, Atom, `/llms.txt`, and `/sitemap-posts.xml` now share public-post filtering for drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ NODE_ENV=production
 
 Blog posts are stored as Markdown files in `src/data/blog/`. In production, the posts directory is mounted as a PersistentVolume, allowing content updates without rebuilding the container.
 
-API-created or API-updated non-draft posts trigger public crawl signals after the Markdown write: IndexNow performs immediate URL submission, and Google uses supported Search Console sitemap resubmission. Draft posts are skipped.
+API-created or API-updated non-draft posts trigger public crawl signals after the Markdown write: IndexNow performs immediate URL submission, Google uses supported Search Console sitemap resubmission, and Yahoo-specific discovery evidence is returned through Bing IndexNow / Yahoo Slurp plus sitemap and robots visibility. Yahoo evidence is not a standalone Yahoo-owned submit endpoint and does not guarantee indexing. Draft posts are skipped.
 
 Durable local blog visuals belong under `public/assets/blog/<post-slug>/` and should be referenced from Markdown as `/assets/blog/<post-slug>/filename.svg` or `/assets/blog/<post-slug>/filename.png`. Use normal Markdown image syntax with useful alt text and a caption/title; inline `data:image` URIs are rejected.
 
@@ -229,7 +229,7 @@ GitHub Actions workflow (`.github/workflows/deploy.yaml`):
 - Interactive pillar modals
 - Dark/light mode toggle
 - Fuzzy search with Pagefind (`/search`; generated `/pagefind/` assets are not crawler-facing content)
-- RSS feed plus canonical `/sitemap.xml` crawler surface (`/sitemap-index.xml` redirects only for compatibility), with public-post crawl signal submission on API publish/update; Google Search Console submission is best-effort and configuration-dependent
+- RSS feed plus canonical `/sitemap.xml` crawler surface (`/sitemap-index.xml` redirects only for compatibility), with public-post crawl signal submission on API publish/update; Google Search Console submission is best-effort and configuration-dependent, and Yahoo discovery evidence is surfaced through Bing IndexNow / Yahoo Slurp without a Yahoo-specific environment variable
 - Dynamic OG image generation
 
 ## 📜 License

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/googleSearchConsole.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/homepagePosts.test.mjs && node tests/homepageFleet.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
+    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/googleSearchConsole.test.mjs && node tests/yahooPostCrawlSignals.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/homepagePosts.test.mjs && node tests/homepageFleet.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:seo-crawl-surface": "node scripts/checkSeoCrawlSurface.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -267,10 +267,9 @@ export const POST: APIRoute = async context => {
     await writeFile(filePath, fileContent, "utf-8");
 
     // Submit public crawl signals if not a draft
-    if (!draft) {
-      const postUrl = `${SITE.website}posts/${slug}/`;
-      await submitPublicPostCrawlSignals(postUrl);
-    }
+    const crawlSignals = !draft
+      ? await submitPublicPostCrawlSignals(`${SITE.website}posts/${slug}/`)
+      : undefined;
 
     return new Response(
       JSON.stringify({
@@ -278,6 +277,7 @@ export const POST: APIRoute = async context => {
         message: "Post created successfully",
         slug,
         filename,
+        crawlSignals,
       }),
       {
         status: 201,
@@ -458,10 +458,9 @@ export const PATCH: APIRoute = async context => {
 
     // Submit public crawl signals if not a draft
     const isDraft = draft !== undefined ? draft : frontmatterData.draft;
-    if (!isDraft) {
-      const postUrl = `${SITE.website}posts/${slug}/`;
-      await submitPublicPostCrawlSignals(postUrl);
-    }
+    const crawlSignals = !isDraft
+      ? await submitPublicPostCrawlSignals(`${SITE.website}posts/${slug}/`)
+      : undefined;
 
     return new Response(
       JSON.stringify({
@@ -473,6 +472,7 @@ export const PATCH: APIRoute = async context => {
             featured !== undefined ? featured : frontmatterData.featured,
           draft: draft !== undefined ? draft : frontmatterData.draft,
         },
+        crawlSignals,
       }),
       {
         status: 200,

--- a/src/utils/publicPostCrawlSignals.ts
+++ b/src/utils/publicPostCrawlSignals.ts
@@ -1,5 +1,6 @@
 import { submitSitemapToGoogleSearchConsole } from "./googleSearchConsole";
 import { submitToIndexNow } from "./indexnow";
+import { submitYahooPostCrawlSignal } from "./yahooPostCrawlSignals";
 
 export interface PublicPostCrawlSignalResult {
   ok: boolean;
@@ -7,11 +8,13 @@ export interface PublicPostCrawlSignalResult {
   reason?: string;
   indexNow?: boolean;
   google?: Awaited<ReturnType<typeof submitSitemapToGoogleSearchConsole>>;
+  yahoo?: Awaited<ReturnType<typeof submitYahooPostCrawlSignal>>;
 }
 
 interface PublicPostCrawlSignalDeps {
   submitIndexNow?: typeof submitToIndexNow;
   submitGoogleSitemap?: typeof submitSitemapToGoogleSearchConsole;
+  submitYahoo?: typeof submitYahooPostCrawlSignal;
 }
 
 export async function submitPublicPostCrawlSignals(
@@ -21,11 +24,16 @@ export async function submitPublicPostCrawlSignals(
     deps?: PublicPostCrawlSignalDeps;
   }
 ): Promise<PublicPostCrawlSignalResult> {
+  const submitYahoo = options?.deps?.submitYahoo ?? submitYahooPostCrawlSignal;
+
   if (options?.isDraft) {
+    const yahoo = await submitYahoo(postUrl, { isDraft: true });
+
     return {
       ok: true,
       skipped: true,
       reason: "draft",
+      yahoo,
     };
   }
 
@@ -33,14 +41,29 @@ export async function submitPublicPostCrawlSignals(
   const submitGoogleSitemap =
     options?.deps?.submitGoogleSitemap ?? submitSitemapToGoogleSearchConsole;
 
-  const [indexNow, google] = await Promise.all([
-    submitIndexNow(postUrl),
-    submitGoogleSitemap(),
-  ]);
+  try {
+    const [indexNow, google] = await Promise.all([
+      submitIndexNow(postUrl),
+      submitGoogleSitemap(),
+    ]);
+    const yahoo = await submitYahoo(postUrl, { indexNowResult: indexNow });
 
-  return {
-    ok: indexNow && (google.ok || google.skipped === true),
-    indexNow,
-    google,
-  };
+    return {
+      ok: indexNow && (google.ok || google.skipped === true),
+      indexNow,
+      google,
+      yahoo,
+    };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : "unknown_error";
+    const yahoo = await submitYahoo(postUrl, {
+      indexNowResult: false,
+    });
+
+    return {
+      ok: false,
+      reason,
+      yahoo,
+    };
+  }
 }

--- a/src/utils/yahooPostCrawlSignals.ts
+++ b/src/utils/yahooPostCrawlSignals.ts
@@ -1,0 +1,80 @@
+import { getCanonicalSitemapUrl } from "./crawlSignals";
+import { submitToIndexNow } from "./indexnow";
+
+export interface YahooPostCrawlSignalResult {
+  ok: boolean;
+  skipped?: boolean;
+  reason?: string;
+  route: "bing_indexnow_yahoo_crawl_discovery";
+  searchEngine: "yahoo";
+  via: "bing_webmaster_tools_indexnow";
+  crawler: "Yahoo Slurp";
+  endpoint: "https://www.bing.com/indexnow";
+  postUrl: string;
+  sitemapUrl: string;
+  robotsTxt: string;
+  indexNowSubmitted?: boolean;
+  guaranteedIndexing: false;
+}
+
+interface YahooPostCrawlSignalDeps {
+  submitIndexNow?: typeof submitToIndexNow;
+}
+
+const YAHOO_SIGNAL_BASE = {
+  route: "bing_indexnow_yahoo_crawl_discovery",
+  searchEngine: "yahoo",
+  via: "bing_webmaster_tools_indexnow",
+  crawler: "Yahoo Slurp",
+  endpoint: "https://www.bing.com/indexnow",
+  robotsTxt: "/robots.txt",
+  guaranteedIndexing: false,
+} as const;
+
+export async function submitYahooPostCrawlSignal(
+  postUrl: string,
+  options?: {
+    isDraft?: boolean;
+    indexNowResult?: boolean;
+    deps?: YahooPostCrawlSignalDeps;
+  }
+): Promise<YahooPostCrawlSignalResult> {
+  const sitemapUrl = getCanonicalSitemapUrl();
+
+  if (options?.isDraft) {
+    return {
+      ...YAHOO_SIGNAL_BASE,
+      ok: true,
+      skipped: true,
+      reason: "draft",
+      postUrl,
+      sitemapUrl,
+    };
+  }
+
+  try {
+    const indexNowSubmitted =
+      options?.indexNowResult ??
+      (await (options?.deps?.submitIndexNow ?? submitToIndexNow)(postUrl));
+
+    return {
+      ...YAHOO_SIGNAL_BASE,
+      ok: indexNowSubmitted,
+      reason: indexNowSubmitted
+        ? undefined
+        : "bing_indexnow_unavailable_for_yahoo_discovery",
+      postUrl,
+      sitemapUrl,
+      indexNowSubmitted,
+    };
+  } catch (error) {
+    return {
+      ...YAHOO_SIGNAL_BASE,
+      ok: false,
+      reason: error instanceof Error ? error.message : "unknown_error",
+      postUrl,
+      sitemapUrl,
+      indexNowSubmitted: false,
+    };
+  }
+}

--- a/tests/googleSearchConsole.test.mjs
+++ b/tests/googleSearchConsole.test.mjs
@@ -93,7 +93,7 @@ async function run() {
     }
   });
 
-  add("public post crawl utility attempts IndexNow and Google but skips drafts", () => {
+  add("public post crawl utility attempts IndexNow, Google, and Yahoo but skips drafts", () => {
     const source = readFileSync(
       new URL("../src/utils/publicPostCrawlSignals.ts", import.meta.url),
       "utf8"
@@ -104,6 +104,7 @@ async function run() {
     assert.match(source, /Promise\.all\(\[/);
     assert.match(source, /submitIndexNow\(postUrl\)/);
     assert.match(source, /submitGoogleSitemap\(\)/);
+    assert.match(source, /submitYahoo\(postUrl, \{ indexNowResult: indexNow \}\)/);
   });
 
   add("posts API only emits public crawl signals inside non-draft create/update branches", () => {
@@ -112,9 +113,8 @@ async function run() {
       "utf8"
     );
 
-    assert.match(source, /submitPublicPostCrawlSignals\(postUrl\)/);
-    assert.match(source, /if \(!draft\) \{[\s\S]*?submitPublicPostCrawlSignals\(postUrl\);[\s\S]*?\}/);
-    assert.match(source, /const isDraft = draft !== undefined \? draft : frontmatterData\.draft;[\s\S]*?if \(!isDraft\) \{[\s\S]*?submitPublicPostCrawlSignals\(postUrl\);[\s\S]*?\}/);
+    assert.match(source, /const crawlSignals = !draft[\s\S]*?submitPublicPostCrawlSignals\(`\$\{SITE\.website\}posts\/\$\{slug\}\/`\)[\s\S]*?: undefined;/);
+    assert.match(source, /const isDraft = draft !== undefined \? draft : frontmatterData\.draft;[\s\S]*?const crawlSignals = !isDraft[\s\S]*?submitPublicPostCrawlSignals\(`\$\{SITE\.website\}posts\/\$\{slug\}\/`\)[\s\S]*?: undefined;/);
   });
 
   for (const [name, fn] of tests) {

--- a/tests/yahooPostCrawlSignals.test.mjs
+++ b/tests/yahooPostCrawlSignals.test.mjs
@@ -1,0 +1,76 @@
+/* eslint-disable no-console */
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+let passed = 0;
+let failed = 0;
+
+const publicSignalsSource = readFileSync(
+  new URL("../src/utils/publicPostCrawlSignals.ts", import.meta.url),
+  "utf8"
+);
+const yahooSignalsSource = readFileSync(
+  new URL("../src/utils/yahooPostCrawlSignals.ts", import.meta.url),
+  "utf8"
+);
+const postsApiSource = readFileSync(
+  new URL("../src/pages/api/posts.ts", import.meta.url),
+  "utf8"
+);
+
+function test(name, fn) {
+  try {
+    fn();
+    passed += 1;
+  } catch (error) {
+    failed += 1;
+    console.error(`FAIL ${name}`);
+    console.error(error);
+  }
+}
+
+test("public post crawl signals include Yahoo-specific evidence via Bing IndexNow", () => {
+  assert.match(publicSignalsSource, /import \{ submitYahooPostCrawlSignal \} from "\.\/yahooPostCrawlSignals"/);
+  assert.match(publicSignalsSource, /const yahoo = await submitYahoo\(postUrl, \{ indexNowResult: indexNow \}\);/);
+  assert.match(publicSignalsSource, /yahoo,/);
+  assert.match(yahooSignalsSource, /searchEngine: "yahoo"/);
+  assert.match(yahooSignalsSource, /via: "bing_webmaster_tools_indexnow"/);
+  assert.match(yahooSignalsSource, /crawler: "Yahoo Slurp"/);
+  assert.match(yahooSignalsSource, /endpoint: "https:\/\/www\.bing\.com\/indexnow"/);
+  assert.match(yahooSignalsSource, /guaranteedIndexing: false/);
+});
+
+test("draft posts skip Yahoo signal without calling IndexNow", () => {
+  assert.match(publicSignalsSource, /if \(options\?\.isDraft\) \{[\s\S]*?submitYahoo\(postUrl, \{ isDraft: true \}\)[\s\S]*?skipped: true[\s\S]*?reason: "draft"/);
+  assert.match(yahooSignalsSource, /if \(options\?\.isDraft\) \{[\s\S]*?skipped: true[\s\S]*?reason: "draft"[\s\S]*?\};[\s\S]*?\}/);
+  assert.doesNotMatch(
+    yahooSignalsSource.match(/if \(options\?\.isDraft\) \{[\s\S]*?\n  \}/)?.[0] ?? "",
+    /submitToIndexNow|submitIndexNow\(postUrl\)/
+  );
+});
+
+test("Yahoo signal unavailable path is observable and non-throwing", () => {
+  assert.match(yahooSignalsSource, /catch \(error\) \{/);
+  assert.match(yahooSignalsSource, /ok: false/);
+  assert.match(yahooSignalsSource, /reason: error instanceof Error \? error\.message : "unknown_error"/);
+  assert.match(yahooSignalsSource, /indexNowSubmitted: false/);
+  assert.match(publicSignalsSource, /catch \(error\) \{/);
+});
+
+test("posts API returns crawl signal evidence only in non-draft create/update branches", () => {
+  assert.match(postsApiSource, /const crawlSignals = !draft[\s\S]*?submitPublicPostCrawlSignals\(`\$\{SITE\.website\}posts\/\$\{slug\}\/`\)[\s\S]*?: undefined;/);
+  assert.match(postsApiSource, /const crawlSignals = !isDraft[\s\S]*?submitPublicPostCrawlSignals\(`\$\{SITE\.website\}posts\/\$\{slug\}\/`\)[\s\S]*?: undefined;/);
+  assert.match(postsApiSource, /crawlSignals,/);
+});
+
+test("Yahoo path avoids fake standalone Yahoo endpoint or indexing guarantee", () => {
+  assert.doesNotMatch(yahooSignalsSource, /yahoo\.com\/indexnow/i);
+  assert.doesNotMatch(yahooSignalsSource, /search\.yahooapis/i);
+  assert.doesNotMatch(yahooSignalsSource, /guaranteedIndexing: true/);
+});
+
+console.log(`PASS ${passed} FAIL ${failed}`);
+
+if (failed > 0) {
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Source issue

Closes #102

Issue: https://github.com/berryhill/bd-site/issues/102

## Classification / path boundary

app/source-code-touching, with docs reconciliation.

## Prior PR audit / decision

Initial intake and branch creation found no existing open or closed PR for issue #102, the `feature/issue-102-yahoo-post-indexing` head branch, or Yahoo indexing keywords, so this flow created a clean feature branch from refreshed `origin/main` and opened PR #105.

Finalize-step audit was re-run across all PR states before push/update:

- `gh pr list --repo berryhill/bd-site --state all --head feature/issue-102-yahoo-post-indexing ...` returned this clean open PR: #105.
- `gh search prs --repo berryhill/bd-site '102 OR "Yahoo" OR "indexing"' --state open ...` returned PR #105.
- `gh search prs --repo berryhill/bd-site '102 OR "Yahoo" OR "indexing"' --state closed ...` returned no closed PRs.
- Decision: update this clean open PR rather than open a duplicate. No contaminated closed prior attempt was found.

## Summary

- Adds `src/utils/yahooPostCrawlSignals.ts`, a Yahoo-specific crawl-signal evidence helper that honestly models Yahoo discovery through Bing IndexNow/Bing Webmaster-style routing plus Yahoo Slurp/sitemap/robots access.
- Wires Yahoo evidence into `submitPublicPostCrawlSignals()` so non-draft post create/update responses distinguish Yahoo status from the generic IndexNow and Google Search Console paths.
- Keeps draft behavior non-indexing: drafts return skipped evidence and do not trigger Yahoo/IndexNow discovery work.
- Keeps the post API non-blocking for unavailable Yahoo discovery: the Yahoo helper returns observable evidence instead of throwing through post creation/update.
- Adds regression coverage for Yahoo evidence shape, draft skip behavior, failure behavior, and the absence of fake standalone Yahoo endpoints or indexing guarantees.

## Documentation reconciliation

- Updates `API.md` with the response-level `crawlSignals.yahoo` evidence contract and the limitation that Yahoo is discovery via Bing IndexNow / Yahoo Slurp, not a standalone Yahoo-owned submit endpoint or guaranteed indexing path.
- Updates `README.md`, `CLAUDE.md`, and `LLM_CRAWL_MANIFEST.md` so future operators and agents preserve the honest Yahoo framing.
- Preserves the issue's Yahoo Help-source constraint: Yahoo site submission is routed through Bing Webmaster Tools, while Yahoo Search can use Yahoo Slurp and Bing crawling.

## Destructive-diff guard output

Finalize guard output:

```text
git diff --name-status origin/main...HEAD
M	API.md
M	CLAUDE.md
M	LLM_CRAWL_MANIFEST.md
M	README.md
M	package.json
M	src/pages/api/posts.ts
M	src/utils/publicPostCrawlSignals.ts
A	src/utils/yahooPostCrawlSignals.ts
M	tests/googleSearchConsole.test.mjs
A	tests/yahooPostCrawlSignals.test.mjs

git diff --stat origin/main...HEAD
10 files changed, 257 insertions(+), 33 deletions(-)
```

No existing source/config/onboarding files are deleted. No `.github/workflows/*` files are added or modified, so no workflow-scope push gate was required. The feature branch is based on current `origin/main` and is ahead 2 / behind 0.

## Validation

Local validation passed after the final documentation commit:

```text
pnpm test
pnpm run lint
pnpm run format:check
pnpm run build
```

Notable output:

```text
PASS terminal prototype fidelity surfaces
eslint .
prettier --check .
All matched files use Prettier code style!
astro build
[build] Complete!
```

GitHub PR readback after push/update:

```text
PR #105: OPEN, non-draft, base main, head feature/issue-102-yahoo-post-indexing
mergeStateStatus: CLEAN
Remote head SHA: 2272246e659ebcc5698122a1184a7393d448fb59
Prior CI readback before this body refresh: Code standards & build (20) SUCCESS
Note: this PR body refresh can trigger another pull_request edited CI run; the next CI Watch step owns current CI readback.
```

## Yahoo limitation, explicitly

This PR does not claim direct Yahoo submission or guaranteed Yahoo indexing. It records Yahoo-specific operator evidence for the best documented automated route available to the site: Bing IndexNow/Bing discovery plus sitemap/robots access for Yahoo Slurp.