### PR TITLE
Fix post detail footer terminal prototype fidelity

### DIFF
--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -207,7 +207,7 @@ const primaryShareHref = footerShareLinks[0]?.href ?? postUrl;
           <span class="n">reader actions</span>
         </div>
         <div
-          class="env post-actions"
+          class="env"
           aria-label="post footer reader actions"
           data-pagefind-ignore
         >
@@ -224,39 +224,26 @@ const primaryShareHref = footerShareLinks[0]?.href ?? postUrl;
             <span><b>SHARE=</b> {post.id}</span>
             <span>send →</span>
           </a>
-          {
-            showEditPost ? (
-              <a
-                href={editPostHref}
-                target="_blank"
-                rel="noopener noreferrer"
-                aria-label="edit this post"
-              >
-                <span>
-                  <b>EDIT=</b> source
-                </span>
-                <span>patch →</span>
-              </a>
-            ) : (
-              <span
-                class="env-disabled"
-                aria-label="edit this post unavailable"
-              >
-                <span>
-                  <b>EDIT=</b> source
-                </span>
-                <span>disabled</span>
-              </span>
-            )
-          }
-          <button
-            type="button"
+          <a
+            href={showEditPost ? editPostHref : "#"}
+            target={showEditPost ? "_blank" : undefined}
+            rel={showEditPost ? "noopener noreferrer" : undefined}
+            aria-label={showEditPost
+              ? "edit this post"
+              : "edit this post unavailable"}
+            aria-disabled={showEditPost ? undefined : "true"}
+          >
+            <span><b>EDIT=</b> source</span>
+            <span>{showEditPost ? "patch →" : "disabled"}</span>
+          </a>
+          <a
+            href="#top"
             aria-label="post operations: scroll to top"
             data-terminal-top
           >
             <span><b>TOP=</b> scroll</span>
             <span>top ↑</span>
-          </button>
+          </a>
         </div>
         <div class="line end-prompt">
           <span class="ps1"

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -3,6 +3,11 @@ import { type CollectionEntry } from "astro:content";
 import { marked } from "marked";
 import Layout from "@/layouts/Layout.astro";
 import RelatedPosts from "@/components/RelatedPosts.astro";
+import IconBrandX from "@/assets/icons/IconBrandX.svg";
+import IconFacebook from "@/assets/icons/IconFacebook.svg";
+import IconMail from "@/assets/icons/IconMail.svg";
+import IconTelegram from "@/assets/icons/IconTelegram.svg";
+import IconWhatsapp from "@/assets/icons/IconWhatsapp.svg";
 import { getPath } from "@/utils/getPath";
 import { getRelatedPosts } from "@/utils/getRelatedPosts";
 import { slugifyStr } from "@/utils/slugify";
@@ -79,6 +84,14 @@ const toc = Array.from((post.body || "").matchAll(/^##\s+(.+)$/gm))
   .map(label => ({ label, href: `#${slugifyStr(label)}` }));
 const published = formatDate(pubDatetime) ?? "pending";
 const updated = formatDate(modDatetime) ?? published;
+const encodedPostUrl = encodeURIComponent(postUrl);
+const encodedShareTitle = encodeURIComponent(`${title} — ${SITE.author}`);
+const shareText = `${title} — ${SITE.author}`;
+const shareXHref = `https://twitter.com/intent/tweet?text=${encodedShareTitle}&url=${encodedPostUrl}`;
+const shareFacebookHref = `https://www.facebook.com/sharer/sharer.php?u=${encodedPostUrl}`;
+const shareWhatsappHref = `https://api.whatsapp.com/send?text=${encodeURIComponent(`${shareText} — ${postUrl}`)}`;
+const shareTelegramHref = `https://t.me/share/url?url=${encodedPostUrl}&text=${encodedShareTitle}`;
+const shareMailHref = `mailto:?subject=${encodedShareTitle}&body=${encodedPostUrl}`;
 ---
 
 <Layout
@@ -189,6 +202,100 @@ const updated = formatDate(modDatetime) ?? published;
             )
           }
           <div class="post-body astro-post-content" set:html={htmlContent} />
+          <div
+            class="post-meta"
+            aria-label="post metadata"
+            data-pagefind-ignore
+          >
+            <div class="tags-row">
+              <span class="meta-label"><b>#</b>tags</span>
+              {
+                postTags.length > 0 ? (
+                  postTags.map(tag => (
+                    <a class="tag" href={`/tags/${slugifyStr(tag)}/`}>
+                      <>
+                        <span class="hash">#</span>
+                        <span>{tag}</span>
+                      </>
+                    </a>
+                  ))
+                ) : (
+                  <span class="tag tag--empty">
+                    <span class="hash">#</span>untagged
+                  </span>
+                )
+              }
+            </div>
+            <div class="share-row" role="group" aria-label="share">
+              <span class="meta-label"><b>$</b>share</span>
+              <div class="share-buttons">
+                <a
+                  id="sh-x"
+                  href={shareXHref}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="Post on X"
+                  title="Post on X"
+                >
+                  <IconBrandX aria-hidden="true" />
+                </a>
+                <a
+                  id="sh-fb"
+                  href={shareFacebookHref}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="Share on Facebook"
+                  title="Share on Facebook"
+                >
+                  <IconFacebook aria-hidden="true" />
+                </a>
+                <a
+                  id="sh-wa"
+                  href={shareWhatsappHref}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="Share on WhatsApp"
+                  title="Share on WhatsApp"
+                >
+                  <IconWhatsapp aria-hidden="true" />
+                </a>
+                <a
+                  id="sh-tg"
+                  href={shareTelegramHref}
+                  target="_blank"
+                  rel="noopener"
+                  aria-label="Share on Telegram"
+                  title="Share on Telegram"
+                >
+                  <IconTelegram aria-hidden="true" />
+                </a>
+                <a
+                  id="sh-mail"
+                  href={shareMailHref}
+                  aria-label="Share via email"
+                  title="Share via email"
+                >
+                  <IconMail aria-hidden="true" />
+                </a>
+                <button
+                  type="button"
+                  id="sh-copy"
+                  data-copy-post-url={postUrl}
+                  aria-label="Copy link to clipboard"
+                  title="Copy link to clipboard"
+                >
+                  <svg data-stroke viewBox="0 0 24 24" aria-hidden="true">
+                    <path
+                      d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"
+                    ></path>
+                    <path
+                      d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"
+                    ></path>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
         <div class="line end-prompt">
           <span class="ps1"
@@ -260,4 +367,17 @@ const updated = formatDate(modDatetime) ?? published;
   window.addEventListener("scroll", tickProgress, { passive: true });
   window.addEventListener("resize", tickProgress);
   tickProgress();
+
+  const copyButton = document.getElementById("sh-copy");
+  copyButton?.addEventListener("click", async () => {
+    const url =
+      copyButton.getAttribute("data-copy-post-url") || window.location.href;
+    try {
+      await navigator.clipboard.writeText(url);
+      copyButton.classList.add("copied");
+      window.setTimeout(() => copyButton.classList.remove("copied"), 1400);
+    } catch {
+      window.location.href = url;
+    }
+  });
 </script>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -2,7 +2,6 @@
 import { type CollectionEntry } from "astro:content";
 import { marked } from "marked";
 import Layout from "@/layouts/Layout.astro";
-import EditPost from "@/components/EditPost.astro";
 import RelatedPosts from "@/components/RelatedPosts.astro";
 import { getPath } from "@/utils/getPath";
 import { getRelatedPosts } from "@/utils/getRelatedPosts";
@@ -86,6 +85,9 @@ const footerShareLinks = SHARE_LINKS.map(social => ({
   ...social,
   href: `${social.href}${encodeURIComponent(postUrl)}`,
 }));
+const editPostHref = `${SITE.editPost.url}${post.filePath}`;
+const showEditPost =
+  SITE.editPost.enabled && !hideEditPost && editPostHref.trim() !== "";
 ---
 
 <Layout
@@ -207,52 +209,75 @@ const footerShareLinks = SHARE_LINKS.map(social => ({
             <span class="n">reader actions</span>
           </div>
           <div class="env terminal-post-footer__env">
+            <div class="terminal-post-footer__card" aria-label="post tags">
+              <span>
+                <b>TAGS=</b>
+                {
+                  postTags.length > 0 ? (
+                    postTags.map((tag, index) => (
+                      <>
+                        {index > 0 && <span class="sep">, </span>}
+                        <a href={`/tags/${slugifyStr(tag)}/`}>#{tag}</a>
+                      </>
+                    ))
+                  ) : (
+                    <span>untagged</span>
+                  )
+                }
+              </span>
+              <span>open →</span>
+            </div>
+            <div
+              class="terminal-post-footer__card"
+              aria-label="share this post"
+            >
+              <span>
+                <b>SHARE=</b>
+                {
+                  footerShareLinks.map((link, index) => (
+                    <>
+                      {index > 0 && <span class="sep"> / </span>}
+                      <a
+                        href={link.href}
+                        title={link.linkTitle}
+                        rel="noopener noreferrer"
+                      >
+                        {link.name.toLowerCase()}
+                      </a>
+                    </>
+                  ))
+                }
+              </span>
+              <span>send →</span>
+            </div>
             {
-              postTags.length > 0 ? (
-                postTags.map(tag => (
-                  <a
-                    href={`/tags/${slugifyStr(tag)}/`}
-                    aria-label={`post tags: ${tag}`}
-                  >
-                    <span>
-                      <b>TAG=</b> #{tag}
-                    </span>
-                    <span>open →</span>
-                  </a>
-                ))
-              ) : (
-                <span
-                  class="terminal-post-footer__empty"
-                  aria-label="post tags"
+              showEditPost ? (
+                <a
+                  class="terminal-post-footer__card"
+                  href={editPostHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="edit this post"
                 >
                   <span>
-                    <b>TAG=</b> untagged
+                    <b>EDIT=</b> source
                   </span>
-                  <span>none</span>
+                  <span>patch →</span>
+                </a>
+              ) : (
+                <span
+                  class="terminal-post-footer__card terminal-post-footer__empty"
+                  aria-label="edit this post unavailable"
+                >
+                  <span>
+                    <b>EDIT=</b> source
+                  </span>
+                  <span>disabled</span>
                 </span>
               )
             }
-            {
-              footerShareLinks.map(link => (
-                <a
-                  href={link.href}
-                  title={link.linkTitle}
-                  rel="noopener noreferrer"
-                  aria-label={`share this post on ${link.name}`}
-                >
-                  <span>
-                    <b>SHARE=</b> {link.name.toLowerCase()}
-                  </span>
-                  <span>send →</span>
-                </a>
-              ))
-            }
-            <EditPost
-              class="terminal-post-footer__edit"
-              {hideEditPost}
-              {post}
-            />
             <button
+              class="terminal-post-footer__card"
               type="button"
               aria-label="post operations: scroll to top"
               data-terminal-top

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -197,60 +197,71 @@ const footerShareLinks = SHARE_LINKS.map(social => ({
           }
           <div class="post-body astro-post-content" set:html={htmlContent} />
         </div>
-        <section class="terminal-post-footer" data-pagefind-ignore>
+        <section
+          class="terminal-post-footer"
+          aria-label="post footer reader actions"
+          data-pagefind-ignore
+        >
           <div class="block-h terminal-post-footer__heading">
             <h2>cat post.meta</h2>
             <span class="n">reader actions</span>
           </div>
           <div class="env terminal-post-footer__env">
-            <nav class="terminal-post-footer__tags" aria-label="post tags">
-              {
-                postTags.length > 0 ? (
-                  postTags.map(tag => (
-                    <a href={`/tags/${slugifyStr(tag)}/`}>
-                      <span>
-                        <b>TAG=</b> #{tag}
-                      </span>
-                      <span>open →</span>
-                    </a>
-                  ))
-                ) : (
-                  <span class="terminal-post-footer__empty">untagged</span>
-                )
-              }
-            </nav>
-            <nav
-              class="terminal-post-footer__share"
-              aria-label="share this post"
-            >
-              {
-                footerShareLinks.map(link => (
+            {
+              postTags.length > 0 ? (
+                postTags.map(tag => (
                   <a
-                    href={link.href}
-                    title={link.linkTitle}
-                    rel="noopener noreferrer"
+                    href={`/tags/${slugifyStr(tag)}/`}
+                    aria-label={`post tags: ${tag}`}
                   >
                     <span>
-                      <b>SHARE=</b> {link.name.toLowerCase()}
+                      <b>TAG=</b> #{tag}
                     </span>
-                    <span>send →</span>
+                    <span>open →</span>
                   </a>
                 ))
-              }
-            </nav>
-            <div class="terminal-post-footer__ops" aria-label="post operations">
-              <EditPost
-                class="terminal-post-footer__edit"
-                {hideEditPost}
-                {post}
-              />
-              <button type="button" data-terminal-top>
-                <span>
-                  <b>TOP=</b> scroll
+              ) : (
+                <span
+                  class="terminal-post-footer__empty"
+                  aria-label="post tags"
+                >
+                  <span>
+                    <b>TAG=</b> untagged
+                  </span>
+                  <span>none</span>
                 </span>
-                <span>top ↑</span>
-              </button>
-            </div>
+              )
+            }
+            {
+              footerShareLinks.map(link => (
+                <a
+                  href={link.href}
+                  title={link.linkTitle}
+                  rel="noopener noreferrer"
+                  aria-label={`share this post on ${link.name}`}
+                >
+                  <span>
+                    <b>SHARE=</b> {link.name.toLowerCase()}
+                  </span>
+                  <span>send →</span>
+                </a>
+              ))
+            }
+            <EditPost
+              class="terminal-post-footer__edit"
+              {hideEditPost}
+              {post}
+            />
+            <button
+              type="button"
+              aria-label="post operations: scroll to top"
+              data-terminal-top
+            >
+              <span>
+                <b>TOP=</b> scroll
+              </span>
+              <span>top ↑</span>
+            </button>
           </div>
         </section>
         <div class="line end-prompt">

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -7,7 +7,6 @@ import { getPath } from "@/utils/getPath";
 import { getRelatedPosts } from "@/utils/getRelatedPosts";
 import { slugifyStr } from "@/utils/slugify";
 import { SITE } from "@/config";
-import { SHARE_LINKS } from "@/constants";
 import { buildBlogPostingJsonLd } from "@/utils/structuredData";
 import { toAbsoluteSiteUrl, toPostUrl } from "@/utils/url";
 
@@ -26,7 +25,6 @@ const {
   pubDatetime,
   modDatetime,
   tags,
-  hideEditPost,
 } = post.data;
 const htmlContent = await marked.parse(post.body || "");
 let ogImageUrl: string | undefined;
@@ -81,16 +79,6 @@ const toc = Array.from((post.body || "").matchAll(/^##\s+(.+)$/gm))
   .map(label => ({ label, href: `#${slugifyStr(label)}` }));
 const published = formatDate(pubDatetime) ?? "pending";
 const updated = formatDate(modDatetime) ?? published;
-const footerShareLinks = SHARE_LINKS.map(social => ({
-  ...social,
-  href: `${social.href}${encodeURIComponent(postUrl)}`,
-}));
-const editPostHref = `${SITE.editPost.url}${post.filePath}`;
-const showEditPost = SITE.editPost.enabled && !hideEditPost;
-const tagSummary = postTags.length > 0 ? postTags.join(", ") : "untagged";
-const primaryTagHref =
-  postTags.length > 0 ? `/tags/${slugifyStr(postTags[0])}/` : "/tags/";
-const primaryShareHref = footerShareLinks[0]?.href ?? postUrl;
 ---
 
 <Layout
@@ -202,49 +190,6 @@ const primaryShareHref = footerShareLinks[0]?.href ?? postUrl;
           }
           <div class="post-body astro-post-content" set:html={htmlContent} />
         </div>
-        <div class="block-h" data-pagefind-ignore>
-          <h2>cat post.meta</h2>
-          <span class="n">reader actions</span>
-        </div>
-        <div
-          class="env"
-          aria-label="post footer reader actions"
-          data-pagefind-ignore
-        >
-          <a href={primaryTagHref} aria-label={`post tags: ${tagSummary}`}>
-            <span><b>TAGS=</b> [{tagSummary}]</span>
-            <span>open →</span>
-          </a>
-          <a
-            href={primaryShareHref}
-            title="Share this post"
-            rel="noopener noreferrer"
-            aria-label="share this post"
-          >
-            <span><b>SHARE=</b> {post.id}</span>
-            <span>send →</span>
-          </a>
-          <a
-            href={showEditPost ? editPostHref : "#"}
-            target={showEditPost ? "_blank" : undefined}
-            rel={showEditPost ? "noopener noreferrer" : undefined}
-            aria-label={showEditPost
-              ? "edit this post"
-              : "edit this post unavailable"}
-            aria-disabled={showEditPost ? undefined : "true"}
-          >
-            <span><b>EDIT=</b> source</span>
-            <span>{showEditPost ? "patch →" : "disabled"}</span>
-          </a>
-          <a
-            href="#top"
-            aria-label="post operations: scroll to top"
-            data-terminal-top
-          >
-            <span><b>TOP=</b> scroll</span>
-            <span>top ↑</span>
-          </a>
-        </div>
         <div class="line end-prompt">
           <span class="ps1"
             >m@berryhill <span class="sep">in</span>
@@ -315,10 +260,4 @@ const primaryShareHref = footerShareLinks[0]?.href ?? postUrl;
   window.addEventListener("scroll", tickProgress, { passive: true });
   window.addEventListener("resize", tickProgress);
   tickProgress();
-
-  document.querySelectorAll("[data-terminal-top]").forEach(button => {
-    button.addEventListener("click", () => {
-      window.scrollTo({ top: 0, behavior: "smooth" });
-    });
-  });
 </script>

--- a/src/layouts/PostDetails.astro
+++ b/src/layouts/PostDetails.astro
@@ -86,8 +86,11 @@ const footerShareLinks = SHARE_LINKS.map(social => ({
   href: `${social.href}${encodeURIComponent(postUrl)}`,
 }));
 const editPostHref = `${SITE.editPost.url}${post.filePath}`;
-const showEditPost =
-  SITE.editPost.enabled && !hideEditPost && editPostHref.trim() !== "";
+const showEditPost = SITE.editPost.enabled && !hideEditPost;
+const tagSummary = postTags.length > 0 ? postTags.join(", ") : "untagged";
+const primaryTagHref =
+  postTags.length > 0 ? `/tags/${slugifyStr(postTags[0])}/` : "/tags/";
+const primaryShareHref = footerShareLinks[0]?.href ?? postUrl;
 ---
 
 <Layout
@@ -199,96 +202,62 @@ const showEditPost =
           }
           <div class="post-body astro-post-content" set:html={htmlContent} />
         </div>
-        <section
-          class="terminal-post-footer"
+        <div class="block-h" data-pagefind-ignore>
+          <h2>cat post.meta</h2>
+          <span class="n">reader actions</span>
+        </div>
+        <div
+          class="env post-actions"
           aria-label="post footer reader actions"
           data-pagefind-ignore
         >
-          <div class="block-h terminal-post-footer__heading">
-            <h2>cat post.meta</h2>
-            <span class="n">reader actions</span>
-          </div>
-          <div class="env terminal-post-footer__env">
-            <div class="terminal-post-footer__card" aria-label="post tags">
-              <span>
-                <b>TAGS=</b>
-                {
-                  postTags.length > 0 ? (
-                    postTags.map((tag, index) => (
-                      <>
-                        {index > 0 && <span class="sep">, </span>}
-                        <a href={`/tags/${slugifyStr(tag)}/`}>#{tag}</a>
-                      </>
-                    ))
-                  ) : (
-                    <span>untagged</span>
-                  )
-                }
-              </span>
-              <span>open →</span>
-            </div>
-            <div
-              class="terminal-post-footer__card"
-              aria-label="share this post"
-            >
-              <span>
-                <b>SHARE=</b>
-                {
-                  footerShareLinks.map((link, index) => (
-                    <>
-                      {index > 0 && <span class="sep"> / </span>}
-                      <a
-                        href={link.href}
-                        title={link.linkTitle}
-                        rel="noopener noreferrer"
-                      >
-                        {link.name.toLowerCase()}
-                      </a>
-                    </>
-                  ))
-                }
-              </span>
-              <span>send →</span>
-            </div>
-            {
-              showEditPost ? (
-                <a
-                  class="terminal-post-footer__card"
-                  href={editPostHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="edit this post"
-                >
-                  <span>
-                    <b>EDIT=</b> source
-                  </span>
-                  <span>patch →</span>
-                </a>
-              ) : (
-                <span
-                  class="terminal-post-footer__card terminal-post-footer__empty"
-                  aria-label="edit this post unavailable"
-                >
-                  <span>
-                    <b>EDIT=</b> source
-                  </span>
-                  <span>disabled</span>
+          <a href={primaryTagHref} aria-label={`post tags: ${tagSummary}`}>
+            <span><b>TAGS=</b> [{tagSummary}]</span>
+            <span>open →</span>
+          </a>
+          <a
+            href={primaryShareHref}
+            title="Share this post"
+            rel="noopener noreferrer"
+            aria-label="share this post"
+          >
+            <span><b>SHARE=</b> {post.id}</span>
+            <span>send →</span>
+          </a>
+          {
+            showEditPost ? (
+              <a
+                href={editPostHref}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-label="edit this post"
+              >
+                <span>
+                  <b>EDIT=</b> source
                 </span>
-              )
-            }
-            <button
-              class="terminal-post-footer__card"
-              type="button"
-              aria-label="post operations: scroll to top"
-              data-terminal-top
-            >
-              <span>
-                <b>TOP=</b> scroll
+                <span>patch →</span>
+              </a>
+            ) : (
+              <span
+                class="env-disabled"
+                aria-label="edit this post unavailable"
+              >
+                <span>
+                  <b>EDIT=</b> source
+                </span>
+                <span>disabled</span>
               </span>
-              <span>top ↑</span>
-            </button>
-          </div>
-        </section>
+            )
+          }
+          <button
+            type="button"
+            aria-label="post operations: scroll to top"
+            data-terminal-top
+          >
+            <span><b>TOP=</b> scroll</span>
+            <span>top ↑</span>
+          </button>
+        </div>
         <div class="line end-prompt">
           <span class="ps1"
             >m@berryhill <span class="sep">in</span>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3281,27 +3281,14 @@ a:hover {
   color: var(--accent);
 }
 .terminal-post-footer {
-  margin-top: 32px;
-  max-width: 68ch;
-}
-.terminal-post-footer__heading {
   margin-top: 0;
 }
-.terminal-post-footer__env {
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-.terminal-post-footer__tags,
-.terminal-post-footer__share,
-.terminal-post-footer__ops {
-  display: contents;
-}
 .terminal-post-footer__env a,
+.terminal-post-footer__env > span,
 .terminal-post-footer__env button {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 14px;
-  min-width: 0;
   padding: 14px 16px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -3317,22 +3304,17 @@ a:hover {
   border-color: var(--accent);
 }
 .terminal-post-footer__env a b,
+.terminal-post-footer__env > span b,
 .terminal-post-footer__env button b {
   color: var(--accent);
   font-weight: 500;
   font-size: 12px;
 }
 .terminal-post-footer__env a span,
+.terminal-post-footer__env > span span,
 .terminal-post-footer__env button span {
-  min-width: 0;
   color: var(--muted);
   font-size: 12px;
-}
-.terminal-post-footer__env a span:first-child,
-.terminal-post-footer__env button span:first-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 .terminal-post-footer__env button {
   cursor: pointer;
@@ -3342,24 +3324,7 @@ a:hover {
   height: 13px;
 }
 .terminal-post-footer__empty {
-  display: flex;
-  align-items: center;
-  padding: 14px 16px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--surface);
   color: var(--dim);
-  font-size: 12px;
-}
-@media (max-width: 920px) {
-  .terminal-post-footer__env {
-    grid-template-columns: 1fr 1fr;
-  }
-}
-@media (max-width: 720px) {
-  .terminal-post-footer__env {
-    grid-template-columns: 1fr;
-  }
 }
 .end-prompt {
   margin-top: 48px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3280,15 +3280,11 @@ a:hover {
   top: 0;
   color: var(--accent);
 }
-.terminal-post-footer {
-  margin-top: 0;
-}
-.terminal-post-footer__env > .terminal-post-footer__card {
+.post-actions button,
+.post-actions .env-disabled {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 14px;
-  min-width: 0;
   padding: 14px 16px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -3299,44 +3295,22 @@ a:hover {
   text-decoration: none;
   transition: border-color 0.15s;
 }
-.terminal-post-footer__env > a.terminal-post-footer__card:hover,
-.terminal-post-footer__env > button.terminal-post-footer__card:hover {
+.post-actions button {
+  cursor: pointer;
+}
+.post-actions button:hover {
   border-color: var(--accent);
 }
-.terminal-post-footer__card b {
+.post-actions button b,
+.post-actions .env-disabled b {
   color: var(--accent);
   font-weight: 500;
   font-size: 12px;
 }
-.terminal-post-footer__card span {
-  min-width: 0;
+.post-actions button span,
+.post-actions .env-disabled span {
   color: var(--muted);
   font-size: 12px;
-}
-.terminal-post-footer__card > span:first-child {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-.terminal-post-footer__card a {
-  display: inline;
-  padding: 0;
-  border: 0;
-  background: transparent;
-  color: var(--info);
-  text-decoration: none;
-}
-.terminal-post-footer__card a:hover {
-  color: var(--accent);
-}
-.terminal-post-footer__card .sep {
-  color: var(--dim);
-}
-.terminal-post-footer__env > button.terminal-post-footer__card {
-  cursor: pointer;
-}
-.terminal-post-footer__empty {
-  color: var(--dim);
 }
 .end-prompt {
   margin-top: 48px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3027,10 +3027,26 @@ a:hover {
   margin: 28px 0 0;
   align-items: start;
 }
+.post-layout > .toc {
+  grid-column: 1;
+  grid-row: 1 / span 2;
+}
+.post-layout > .post-body {
+  grid-column: 2;
+  grid-row: 1;
+}
+.post-layout > .post-meta {
+  grid-column: 2;
+  grid-row: 2;
+}
 @media (max-width: 900px) {
   .post-layout {
     grid-template-columns: 1fr;
     gap: 0;
+  }
+  .post-layout > .post-body,
+  .post-layout > .post-meta {
+    grid-column: 1;
   }
 }
 .toc {
@@ -3279,6 +3295,115 @@ a:hover {
   left: 0;
   top: 0;
   color: var(--accent);
+}
+.post-meta {
+  max-width: 68ch;
+  margin-top: 48px;
+  padding: 18px 0;
+  border-top: 1px dashed var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  flex-wrap: wrap;
+  font-size: 12.5px;
+}
+@media (max-width: 720px) {
+  .post-meta {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+}
+.post-meta .meta-label {
+  color: var(--dim);
+  font-size: 11px;
+  letter-spacing: 0.14em;
+  text-transform: lowercase;
+  margin-right: 4px;
+  white-space: nowrap;
+}
+.post-meta .meta-label b {
+  color: var(--accent);
+  font-weight: 500;
+  margin-right: 4px;
+}
+.tags-row {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 12px;
+  font-family: var(--font-mono);
+}
+.tags-row a.tag,
+.tags-row .tag--empty {
+  color: var(--info);
+  font-size: 13px;
+  text-decoration: none;
+  letter-spacing: -0.005em;
+  transition: color 0.15s;
+}
+.tags-row a.tag:hover {
+  color: var(--accent);
+}
+.tags-row a.tag .hash,
+.tags-row .tag--empty .hash {
+  color: var(--info);
+  opacity: 0.65;
+  margin-right: 1px;
+}
+.tags-row a.tag:hover .hash {
+  color: var(--accent);
+  opacity: 1;
+}
+.share-row {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.share-buttons {
+  display: inline-flex;
+  gap: 4px;
+}
+.share-buttons a,
+.share-buttons button {
+  width: 26px;
+  height: 26px;
+  display: inline-grid;
+  place-items: center;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--muted);
+  cursor: pointer;
+  padding: 0;
+  text-decoration: none;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+.share-buttons a:hover,
+.share-buttons button:hover {
+  background: var(--surface-2);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.share-buttons svg {
+  width: 13px;
+  height: 13px;
+  fill: currentColor;
+  stroke: currentColor;
+}
+.share-buttons svg[data-stroke] {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+}
+.share-buttons button.copied {
+  border-color: var(--accent);
+  color: var(--accent);
+  background: oklch(20% 0.05 145 / 0.4);
 }
 .end-prompt {
   margin-top: 48px;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3283,12 +3283,12 @@ a:hover {
 .terminal-post-footer {
   margin-top: 0;
 }
-.terminal-post-footer__env a,
-.terminal-post-footer__env > span,
-.terminal-post-footer__env button {
+.terminal-post-footer__env > .terminal-post-footer__card {
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 14px;
+  min-width: 0;
   padding: 14px 16px;
   border: 1px solid var(--border);
   border-radius: 6px;
@@ -3299,29 +3299,41 @@ a:hover {
   text-decoration: none;
   transition: border-color 0.15s;
 }
-.terminal-post-footer__env a:hover,
-.terminal-post-footer__env button:hover {
+.terminal-post-footer__env > a.terminal-post-footer__card:hover,
+.terminal-post-footer__env > button.terminal-post-footer__card:hover {
   border-color: var(--accent);
 }
-.terminal-post-footer__env a b,
-.terminal-post-footer__env > span b,
-.terminal-post-footer__env button b {
+.terminal-post-footer__card b {
   color: var(--accent);
   font-weight: 500;
   font-size: 12px;
 }
-.terminal-post-footer__env a span,
-.terminal-post-footer__env > span span,
-.terminal-post-footer__env button span {
+.terminal-post-footer__card span {
+  min-width: 0;
   color: var(--muted);
   font-size: 12px;
 }
-.terminal-post-footer__env button {
-  cursor: pointer;
+.terminal-post-footer__card > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
-.terminal-post-footer__edit svg {
-  width: 13px;
-  height: 13px;
+.terminal-post-footer__card a {
+  display: inline;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--info);
+  text-decoration: none;
+}
+.terminal-post-footer__card a:hover {
+  color: var(--accent);
+}
+.terminal-post-footer__card .sep {
+  color: var(--dim);
+}
+.terminal-post-footer__env > button.terminal-post-footer__card {
+  cursor: pointer;
 }
 .terminal-post-footer__empty {
   color: var(--dim);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -3280,38 +3280,6 @@ a:hover {
   top: 0;
   color: var(--accent);
 }
-.post-actions button,
-.post-actions .env-disabled {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 14px 16px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--surface);
-  color: var(--fg);
-  font: inherit;
-  text-align: left;
-  text-decoration: none;
-  transition: border-color 0.15s;
-}
-.post-actions button {
-  cursor: pointer;
-}
-.post-actions button:hover {
-  border-color: var(--accent);
-}
-.post-actions button b,
-.post-actions .env-disabled b {
-  color: var(--accent);
-  font-weight: 500;
-  font-size: 12px;
-}
-.post-actions button span,
-.post-actions .env-disabled span {
-  color: var(--muted);
-  font-size: 12px;
-}
 .end-prompt {
   margin-top: 48px;
 }

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -206,17 +206,24 @@ assert.match(terminalPostFooterMarkup, /class=\"block-h terminal-post-footer__he
 assert.match(terminalPostFooterMarkup, /<h2>cat post\.meta<\/h2>/);
 assert.match(terminalPostFooterMarkup, /<span class=\"n\">reader actions<\/span>/);
 assert.match(terminalPostFooterMarkup, /class=\"env terminal-post-footer__env\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\{`post tags: \$\{tag\}`\}/);
-assert.match(terminalPostFooterMarkup, /aria-label=\{`share this post on \$\{link\.name\}`\}/);
+assert.match(terminalPostFooterMarkup, /aria-label=\"post tags\"/);
+assert.match(terminalPostFooterMarkup, /aria-label=\"share this post\"/);
+assert.match(terminalPostFooterMarkup, /aria-label=\"edit this post/);
 assert.match(terminalPostFooterMarkup, /aria-label=\"post operations: scroll to top\"/);
-assert.match(terminalPostFooterMarkup, /<b>TAG=<\/b> #\{tag\}/);
-assert.match(terminalPostFooterMarkup, /<b>SHARE=<\/b> \{link\.name\.toLowerCase\(\)\}/);
+assert.match(terminalPostFooterMarkup, /<b>TAGS=<\/b>/);
+assert.match(terminalPostFooterMarkup, /<b>SHARE=<\/b>/);
+assert.match(terminalPostFooterMarkup, /<b>EDIT=<\/b> source/);
 assert.match(terminalPostFooterMarkup, /<b>TOP=<\/b> scroll/);
 assert.match(terminalPostFooterMarkup, /href=\{`\/tags\/\$\{slugifyStr\(tag\)\}\/`\}/);
 assert.match(sources.postDetail, /encodeURIComponent\(postUrl\)/);
 assert.match(terminalPostFooterMarkup, /postTags\.length > 0/);
-assert.match(terminalPostFooterMarkup, /terminal-post-footer__empty/);
+assert.match(terminalPostFooterMarkup, /showEditPost/);
 assert.match(terminalPostFooterMarkup, /data-terminal-top/);
+const footerCards = terminalPostFooterMarkup.match(/terminal-post-footer__card/g) ?? [];
+assert.ok(
+  footerCards.length >= 4 && footerCards.length <= 6,
+  "issue #89 footer must collapse to the prototype-sized 2x2 env surface, not render one card per tag/share provider"
+);
 assert.doesNotMatch(
   terminalPostFooterMarkup,
   /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|terminal-post-footer__tags|terminal-post-footer__share|terminal-post-footer__ops|<span class=\"terminal-post-footer__label\">(?:tags|share|ops)<\/span>|\$ tail -f post\.meta|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
@@ -230,7 +237,7 @@ assert.doesNotMatch(
 assert.match(sources.styles, /\.terminal-post-footer \{/);
 assert.match(
   sources.styles,
-  /\.terminal-post-footer__env a,\s*\n\.terminal-post-footer__env > span,\s*\n\.terminal-post-footer__env button \{/
+  /\.terminal-post-footer__env > \.terminal-post-footer__card \{/
 );
 const compactPostFooterCss =
   sources.styles.match(/\.terminal-post-footer \{[\s\S]*?\.end-prompt \{/)?.[0] ?? "";

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -198,70 +198,28 @@ assert.match(sources.about, /class=\"terminal-exit\"/, "about bottom rail must u
 assert.match(sources.about, /<span class=\"eof\">EOF<\/span>/, "about bottom rail must show an EOF marker");
 assert.doesNotMatch(sources.about, /If you want to hire me/, "about CTA must use the issue #81 approved wording");
 
-const terminalPostFooterMarkup = sources.postDetail.match(
-  /<section[\s\S]*?class=\"terminal-post-footer\"[\s\S]*?<\/section>/
-)?.[0] ?? "";
-assert.ok(terminalPostFooterMarkup, "post detail must restore the issue #89 terminal post footer card");
-assert.match(terminalPostFooterMarkup, /class=\"block-h terminal-post-footer__heading\"/);
-assert.match(terminalPostFooterMarkup, /<h2>cat post\.meta<\/h2>/);
-assert.match(terminalPostFooterMarkup, /<span class=\"n\">reader actions<\/span>/);
-assert.match(terminalPostFooterMarkup, /class=\"env terminal-post-footer__env\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"post tags\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"share this post\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"edit this post/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"post operations: scroll to top\"/);
-assert.match(terminalPostFooterMarkup, /<b>TAGS=<\/b>/);
-assert.match(terminalPostFooterMarkup, /<b>SHARE=<\/b>/);
-assert.match(terminalPostFooterMarkup, /<b>EDIT=<\/b> source/);
-assert.match(terminalPostFooterMarkup, /<b>TOP=<\/b> scroll/);
-assert.match(terminalPostFooterMarkup, /href=\{`\/tags\/\$\{slugifyStr\(tag\)\}\/`\}/);
-assert.match(sources.postDetail, /encodeURIComponent\(postUrl\)/);
-assert.match(terminalPostFooterMarkup, /postTags\.length > 0/);
-assert.match(terminalPostFooterMarkup, /showEditPost/);
-assert.match(terminalPostFooterMarkup, /data-terminal-top/);
-const footerCards = terminalPostFooterMarkup.match(/terminal-post-footer__card/g) ?? [];
-assert.ok(
-  footerCards.length >= 4 && footerCards.length <= 6,
-  "issue #89 footer must collapse to the prototype-sized 2x2 env surface, not render one card per tag/share provider"
-);
-assert.doesNotMatch(
-  terminalPostFooterMarkup,
-  /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|terminal-post-footer__tags|terminal-post-footer__share|terminal-post-footer__ops|<span class=\"terminal-post-footer__label\">(?:tags|share|ops)<\/span>|\$ tail -f post\.meta|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
-  "post detail footer must use direct raw terminal.html block-h/env primitives, not rejected bespoke chip/footer chrome"
-);
-assert.doesNotMatch(
-  terminalPostFooterMarkup,
-  /<nav[\s\S]*terminal-post-footer|display: contents/,
-  "post detail footer must not depend on wrapper nav/display:contents layout to fake the prototype env grid"
-);
-assert.match(sources.styles, /\.terminal-post-footer \{/);
-assert.match(
-  sources.styles,
-  /\.terminal-post-footer__env > \.terminal-post-footer__card \{/
-);
-const compactPostFooterCss =
-  sources.styles.match(/\.terminal-post-footer \{[\s\S]*?\.end-prompt \{/)?.[0] ?? "";
-assert.ok(compactPostFooterCss, "post detail footer CSS block must be present");
-assert.doesNotMatch(compactPostFooterCss, /max-width:\s*68ch;/);
-assert.doesNotMatch(compactPostFooterCss, /grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/);
-assert.match(sources.styles, /\.env \{[\s\S]*?grid-template-columns:\s*1fr 1fr;/);
-assert.match(compactPostFooterCss, /padding:\s*14px 16px;/);
-assert.match(compactPostFooterCss, /border:\s*1px solid var\(--border\);/);
-assert.match(compactPostFooterCss, /border-radius:\s*6px;/);
-assert.match(compactPostFooterCss, /background:\s*var\(--surface\);/);
-assert.match(compactPostFooterCss, /transition:\s*border-color 0\.15s;/);
-assert.match(sources.styles, /@media \(max-width: 720px\) \{\s*\.env \{\s*grid-template-columns:\s*1fr;/);
-assert.doesNotMatch(compactPostFooterCss, /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|display:\s*contents/);
-assert.doesNotMatch(compactPostFooterCss, /border-left:\s*2px solid var\(--accent\);/);
-assert.doesNotMatch(compactPostFooterCss, /grid-template-columns:\s*62px 1fr;/);
-assert.doesNotMatch(compactPostFooterCss, /grid-template-columns:\s*minmax\(0, 1fr\) auto;/);
 const postFooterSequence = sources.postDetail.match(
-  /<section[\s\S]*?class=\"terminal-post-footer\"[\s\S]*?<div class=\"line end-prompt\">[\s\S]*?<nav class=\"adjacent\"[\s\S]*?<a class=\"back\"/
+  /<div class="block-h" data-pagefind-ignore>[\s\S]*?<div class="line end-prompt">[\s\S]*?<nav class="adjacent"[\s\S]*?<a class="back"/
 )?.[0] ?? "";
-assert.ok(
+assert.ok(postFooterSequence, "post detail footer must use the raw terminal.html block-h/env sequence before end prompt, adjacent posts, and back-link");
+assert.match(postFooterSequence, /<h2>cat post\.meta<\/h2>/);
+assert.match(postFooterSequence, /<span class="n">reader actions<\/span>/);
+assert.match(postFooterSequence, /class="env post-actions"/);
+assert.match(postFooterSequence, /<b>TAGS=<\/b> \[\{tagSummary\}\]/);
+assert.match(postFooterSequence, /<b>SHARE=<\/b> \{post\.id\}/);
+assert.match(postFooterSequence, /<b>EDIT=<\/b> source/);
+assert.match(postFooterSequence, /<b>TOP=<\/b> scroll/);
+assert.match(postFooterSequence, /primaryTagHref/);
+assert.match(postFooterSequence, /primaryShareHref/);
+assert.match(postFooterSequence, /data-terminal-top/);
+assert.doesNotMatch(
   postFooterSequence,
-  "post detail footer must flow from restored footer card to end-prompt, adjacent-post cards, and back-link"
+  /terminal-post-footer|terminal-post-footer__|terminal-post-footer__card|terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
+  "post detail footer must use raw terminal.html block-h/env primitives, not custom terminal-post-footer chrome"
 );
+assert.match(sources.styles, /\.env \{[\s\S]*?grid-template-columns:\s*1fr 1fr;/);
+assert.match(sources.styles, /\.env a \{[\s\S]*?padding:\s*14px 16px;/);
+assert.match(sources.styles, /@media \(max-width: 720px\) \{\s*\.env \{\s*grid-template-columns:\s*1fr;/);
 assert.match(postFooterSequence, /<span class=\"cmd\">\$ <\/span>/);
 assert.match(postFooterSequence, /aria-label=\"adjacent posts\"/);
 

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -199,16 +199,16 @@ assert.match(sources.about, /<span class=\"eof\">EOF<\/span>/, "about bottom rai
 assert.doesNotMatch(sources.about, /If you want to hire me/, "about CTA must use the issue #81 approved wording");
 
 const terminalPostFooterMarkup = sources.postDetail.match(
-  /<section class=\"terminal-post-footer\"[\s\S]*?<\/section>/
+  /<section[\s\S]*?class=\"terminal-post-footer\"[\s\S]*?<\/section>/
 )?.[0] ?? "";
 assert.ok(terminalPostFooterMarkup, "post detail must restore the issue #89 terminal post footer card");
 assert.match(terminalPostFooterMarkup, /class=\"block-h terminal-post-footer__heading\"/);
 assert.match(terminalPostFooterMarkup, /<h2>cat post\.meta<\/h2>/);
 assert.match(terminalPostFooterMarkup, /<span class=\"n\">reader actions<\/span>/);
 assert.match(terminalPostFooterMarkup, /class=\"env terminal-post-footer__env\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"post tags\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"share this post\"/);
-assert.match(terminalPostFooterMarkup, /aria-label=\"post operations\"/);
+assert.match(terminalPostFooterMarkup, /aria-label=\{`post tags: \$\{tag\}`\}/);
+assert.match(terminalPostFooterMarkup, /aria-label=\{`share this post on \$\{link\.name\}`\}/);
+assert.match(terminalPostFooterMarkup, /aria-label=\"post operations: scroll to top\"/);
 assert.match(terminalPostFooterMarkup, /<b>TAG=<\/b> #\{tag\}/);
 assert.match(terminalPostFooterMarkup, /<b>SHARE=<\/b> \{link\.name\.toLowerCase\(\)\}/);
 assert.match(terminalPostFooterMarkup, /<b>TOP=<\/b> scroll/);
@@ -219,29 +219,37 @@ assert.match(terminalPostFooterMarkup, /terminal-post-footer__empty/);
 assert.match(terminalPostFooterMarkup, /data-terminal-top/);
 assert.doesNotMatch(
   terminalPostFooterMarkup,
-  /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|<span class=\"terminal-post-footer__label\">(?:tags|share|ops)<\/span>|\$ tail -f post\.meta|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
-  "post detail footer must use the raw terminal.html block-h/env language, not the rejected bespoke chip/footer chrome"
+  /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|terminal-post-footer__tags|terminal-post-footer__share|terminal-post-footer__ops|<span class=\"terminal-post-footer__label\">(?:tags|share|ops)<\/span>|\$ tail -f post\.meta|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
+  "post detail footer must use direct raw terminal.html block-h/env primitives, not rejected bespoke chip/footer chrome"
+);
+assert.doesNotMatch(
+  terminalPostFooterMarkup,
+  /<nav[\s\S]*terminal-post-footer|display: contents/,
+  "post detail footer must not depend on wrapper nav/display:contents layout to fake the prototype env grid"
 );
 assert.match(sources.styles, /\.terminal-post-footer \{/);
-assert.match(sources.styles, /\.terminal-post-footer__env \{/);
-assert.match(sources.styles, /\.terminal-post-footer__env a,\s*\n\.terminal-post-footer__env button \{/);
+assert.match(
+  sources.styles,
+  /\.terminal-post-footer__env a,\s*\n\.terminal-post-footer__env > span,\s*\n\.terminal-post-footer__env button \{/
+);
 const compactPostFooterCss =
   sources.styles.match(/\.terminal-post-footer \{[\s\S]*?\.end-prompt \{/)?.[0] ?? "";
 assert.ok(compactPostFooterCss, "post detail footer CSS block must be present");
-assert.match(compactPostFooterCss, /max-width:\s*68ch;/);
-assert.match(compactPostFooterCss, /\.terminal-post-footer__env \{[\s\S]*?grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/);
+assert.doesNotMatch(compactPostFooterCss, /max-width:\s*68ch;/);
+assert.doesNotMatch(compactPostFooterCss, /grid-template-columns:\s*repeat\(3, minmax\(0, 1fr\)\);/);
+assert.match(sources.styles, /\.env \{[\s\S]*?grid-template-columns:\s*1fr 1fr;/);
 assert.match(compactPostFooterCss, /padding:\s*14px 16px;/);
 assert.match(compactPostFooterCss, /border:\s*1px solid var\(--border\);/);
 assert.match(compactPostFooterCss, /border-radius:\s*6px;/);
 assert.match(compactPostFooterCss, /background:\s*var\(--surface\);/);
 assert.match(compactPostFooterCss, /transition:\s*border-color 0\.15s;/);
-assert.match(compactPostFooterCss, /@media \(max-width: 720px\) \{[\s\S]*?grid-template-columns:\s*1fr;/);
-assert.doesNotMatch(compactPostFooterCss, /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label/);
+assert.match(sources.styles, /@media \(max-width: 720px\) \{\s*\.env \{\s*grid-template-columns:\s*1fr;/);
+assert.doesNotMatch(compactPostFooterCss, /terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|display:\s*contents/);
 assert.doesNotMatch(compactPostFooterCss, /border-left:\s*2px solid var\(--accent\);/);
 assert.doesNotMatch(compactPostFooterCss, /grid-template-columns:\s*62px 1fr;/);
 assert.doesNotMatch(compactPostFooterCss, /grid-template-columns:\s*minmax\(0, 1fr\) auto;/);
 const postFooterSequence = sources.postDetail.match(
-  /<section class=\"terminal-post-footer\"[\s\S]*?<div class=\"line end-prompt\">[\s\S]*?<nav class=\"adjacent\"[\s\S]*?<a class=\"back\"/
+  /<section[\s\S]*?class=\"terminal-post-footer\"[\s\S]*?<div class=\"line end-prompt\">[\s\S]*?<nav class=\"adjacent\"[\s\S]*?<a class=\"back\"/
 )?.[0] ?? "";
 assert.ok(
   postFooterSequence,

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -198,23 +198,42 @@ assert.match(sources.about, /class=\"terminal-exit\"/, "about bottom rail must u
 assert.match(sources.about, /<span class=\"eof\">EOF<\/span>/, "about bottom rail must show an EOF marker");
 assert.doesNotMatch(sources.about, /If you want to hire me/, "about CTA must use the issue #81 approved wording");
 
-const postFooterSequence = sources.postDetail.match(
-  /<div class="line end-prompt">[\s\S]*?<nav class="adjacent"[\s\S]*?<a class="back"/
+const postMetaSequence = sources.postDetail.match(
+  /<div[\s\S]*?class="post-meta"[\s\S]*?aria-label="post metadata"[\s\S]*?<div class="line end-prompt">[\s\S]*?<nav class="adjacent"[\s\S]*?<a class="back"/
 )?.[0] ?? "";
-assert.ok(postFooterSequence, "post detail footer must match the terminal prototype: end prompt, adjacent posts, then back-link");
+assert.ok(
+  postMetaSequence,
+  "post detail must preserve the supplied prototype sequence: post-meta tags/share row, end prompt, adjacent posts, then back-link"
+);
 assert.doesNotMatch(
   sources.postDetail,
   /cat post\.meta|reader actions|<b>TAGS=<\/b>|<b>SHARE=<\/b>|<b>EDIT=<\/b>|<b>TOP=<\/b>|primaryTagHref|primaryShareHref|data-terminal-top|terminal-post-footer|terminal-post-footer__|post-actions|env-disabled|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
-  "post detail must not insert a custom reader-actions/env footer; the supplied prototype has no such block"
+  "post detail must not reintroduce rejected custom reader-actions/env footer chrome"
 );
-assert.match(postFooterSequence, /class="line end-prompt"/);
-assert.match(postFooterSequence, /<nav class="adjacent"/);
-assert.match(postFooterSequence, /<a\s+class="back"/);
-assert.match(sources.styles, /\.env \{[\s\S]*?grid-template-columns:\s*1fr 1fr;/);
-assert.match(sources.styles, /\.env a \{[\s\S]*?padding:\s*14px 16px;/);
-assert.match(sources.styles, /@media \(max-width: 720px\) \{\s*\.env \{\s*grid-template-columns:\s*1fr;/);
-assert.match(postFooterSequence, /<span class=\"cmd\">\$ <\/span>/);
-assert.match(postFooterSequence, /aria-label=\"adjacent posts\"/);
+assert.match(postMetaSequence, /class="post-meta"/);
+assert.match(postMetaSequence, /aria-label="post metadata"/);
+assert.match(postMetaSequence, /<div class="tags-row">/);
+assert.match(postMetaSequence, /<span class="meta-label"><b>#<\/b>tags<\/span>/);
+assert.match(postMetaSequence, /<a class="tag" href=\{`\/tags\/\$\{slugifyStr\(tag\)\}\/`\}>/);
+assert.match(postMetaSequence, /<span class="hash">#<\/span>/);
+assert.match(postMetaSequence, /<div class="share-row" role="group" aria-label="share">/);
+assert.match(postMetaSequence, /<span class="meta-label"><b>\$<\/b>share<\/span>/);
+assert.match(postMetaSequence, /<div class="share-buttons">/);
+assert.match(postMetaSequence, /id="sh-x"/);
+assert.match(postMetaSequence, /id="sh-fb"/);
+assert.match(postMetaSequence, /id="sh-wa"/);
+assert.match(postMetaSequence, /id="sh-tg"/);
+assert.match(postMetaSequence, /id="sh-mail"/);
+assert.match(postMetaSequence, /id="sh-copy"/);
+assert.match(postMetaSequence, /class="line end-prompt"/);
+assert.match(postMetaSequence, /<nav class="adjacent"/);
+assert.match(postMetaSequence, /<a\s+class="back"/);
+assert.match(sources.styles, /\.post-meta \{[\s\S]*?max-width:\s*68ch;[\s\S]*?margin-top:\s*48px;[\s\S]*?border-top:\s*1px dashed var\(--border\);/);
+assert.match(sources.styles, /\.tags-row \{[\s\S]*?display:\s*inline-flex;[\s\S]*?gap:\s*4px 12px;/);
+assert.match(sources.styles, /\.share-buttons a,\s*\n\.share-buttons button \{[\s\S]*?width:\s*26px;[\s\S]*?height:\s*26px;/);
+assert.match(sources.styles, /\.share-buttons svg \{[\s\S]*?width:\s*13px;[\s\S]*?height:\s*13px;/);
+assert.match(postMetaSequence, /<span class=\"cmd\">\$ <\/span>/);
+assert.match(postMetaSequence, /aria-label=\"adjacent posts\"/);
 
 for (const [name, source] of [
   ["archivesRoute", sources.archivesRoute],

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -199,25 +199,17 @@ assert.match(sources.about, /<span class=\"eof\">EOF<\/span>/, "about bottom rai
 assert.doesNotMatch(sources.about, /If you want to hire me/, "about CTA must use the issue #81 approved wording");
 
 const postFooterSequence = sources.postDetail.match(
-  /<div class="block-h" data-pagefind-ignore>[\s\S]*?<div class="line end-prompt">[\s\S]*?<nav class="adjacent"[\s\S]*?<a class="back"/
+  /<div class="line end-prompt">[\s\S]*?<nav class="adjacent"[\s\S]*?<a class="back"/
 )?.[0] ?? "";
-assert.ok(postFooterSequence, "post detail footer must use the raw terminal.html block-h/env sequence before end prompt, adjacent posts, and back-link");
-assert.match(postFooterSequence, /<h2>cat post\.meta<\/h2>/);
-assert.match(postFooterSequence, /<span class="n">reader actions<\/span>/);
-assert.match(postFooterSequence, /class="env"/);
-assert.doesNotMatch(postFooterSequence, /class="env post-actions"|<button|env-disabled|post-actions/);
-assert.match(postFooterSequence, /<b>TAGS=<\/b> \[\{tagSummary\}\]/);
-assert.match(postFooterSequence, /<b>SHARE=<\/b> \{post\.id\}/);
-assert.match(postFooterSequence, /<b>EDIT=<\/b> source/);
-assert.match(postFooterSequence, /<b>TOP=<\/b> scroll/);
-assert.match(postFooterSequence, /primaryTagHref/);
-assert.match(postFooterSequence, /primaryShareHref/);
-assert.match(postFooterSequence, /data-terminal-top/);
+assert.ok(postFooterSequence, "post detail footer must match the terminal prototype: end prompt, adjacent posts, then back-link");
 assert.doesNotMatch(
-  postFooterSequence,
-  /terminal-post-footer|terminal-post-footer__|terminal-post-footer__card|terminal-post-footer__rail|terminal-post-footer__row|terminal-post-footer__items|terminal-post-footer__chip|terminal-post-footer__group|terminal-post-footer__label|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
-  "post detail footer must use raw terminal.html block-h/env primitives, not custom terminal-post-footer chrome"
+  sources.postDetail,
+  /cat post\.meta|reader actions|<b>TAGS=<\/b>|<b>SHARE=<\/b>|<b>EDIT=<\/b>|<b>TOP=<\/b>|primaryTagHref|primaryShareHref|data-terminal-top|terminal-post-footer|terminal-post-footer__|post-actions|env-disabled|<ShareLinks|Share this post on:|post tools|<Tag tag=|mt-2 mb-6/,
+  "post detail must not insert a custom reader-actions/env footer; the supplied prototype has no such block"
 );
+assert.match(postFooterSequence, /class="line end-prompt"/);
+assert.match(postFooterSequence, /<nav class="adjacent"/);
+assert.match(postFooterSequence, /<a\s+class="back"/);
 assert.match(sources.styles, /\.env \{[\s\S]*?grid-template-columns:\s*1fr 1fr;/);
 assert.match(sources.styles, /\.env a \{[\s\S]*?padding:\s*14px 16px;/);
 assert.match(sources.styles, /@media \(max-width: 720px\) \{\s*\.env \{\s*grid-template-columns:\s*1fr;/);

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -204,7 +204,8 @@ const postFooterSequence = sources.postDetail.match(
 assert.ok(postFooterSequence, "post detail footer must use the raw terminal.html block-h/env sequence before end prompt, adjacent posts, and back-link");
 assert.match(postFooterSequence, /<h2>cat post\.meta<\/h2>/);
 assert.match(postFooterSequence, /<span class="n">reader actions<\/span>/);
-assert.match(postFooterSequence, /class="env post-actions"/);
+assert.match(postFooterSequence, /class="env"/);
+assert.doesNotMatch(postFooterSequence, /class="env post-actions"|<button|env-disabled|post-actions/);
 assert.match(postFooterSequence, /<b>TAGS=<\/b> \[\{tagSummary\}\]/);
 assert.match(postFooterSequence, /<b>SHARE=<\/b> \{post\.id\}/);
 assert.match(postFooterSequence, /<b>EDIT=<\/b> source/);


### PR DESCRIPTION
Closes #89

## Source issue

- Issue: https://github.com/berryhill/bd-site/issues/89
- Active contract: Matt's latest PR comments require the post detail metadata footer to match the supplied `berryhill-post-detail-terminal.html` design: a tag list plus social/share icons, not an invented reader-actions/env grid and not deletion.

## Final correction

Commit `74fa2b6` restores the actual supplied prototype section:

```html
<div class="post-meta" aria-label="post metadata">
  <div class="tags-row">
    <span class="meta-label"><b>#</b>tags</span>
    <a class="tag"><span class="hash">#</span>...</a>
  </div>
  <div class="share-row" role="group" aria-label="share">
    <span class="meta-label"><b>$</b>share</span>
    <div class="share-buttons">...</div>
  </div>
</div>
```

Implemented details:

- Restores `post-meta` after `.post-body` and before the terminal end prompt.
- Restores `tags-row`, `meta-label`, `tag`, `hash`, `share-row`, and `share-buttons` anchors from the supplied design.
- Renders real tag links from post frontmatter.
- Renders share controls: `sh-x`, `sh-fb`, `sh-wa`, `sh-tg`, `sh-mail`, and `sh-copy`.
- Keeps adjacent post navigation and back link after the end prompt.
- Removes the rejected custom `cat post.meta` / `reader actions` / `TAGS=` / `SHARE=` env-grid chrome.

## Files changed

- `src/layouts/PostDetails.astro`
- `src/styles/global.css`
- `tests/terminalBrandSurfaces.test.mjs`

## Validation

Local validation from the task worktree:

```text
pnpm run format:check: PASS
pnpm test: PASS
pnpm run lint: PASS
pnpm run build: PASS
```

Browser DOM/computed-style readback on `/posts/welcome-to-dynamic-blog/` confirmed:

```json
{
  "postMetaExists": true,
  "sectionOrder": ["post-layout", "line end-prompt", "adjacent", "back"],
  "tags": ["# test", "# dynamic", "# astro"],
  "shareControls": ["sh-x", "sh-fb", "sh-wa", "sh-tg", "sh-mail", "sh-copy"],
  "shareButtonSize": "26x26",
  "iconSize": "13x13",
  "postMetaStyle": {
    "display": "flex",
    "borderTop": "1px dashed var(--border)",
    "marginTop": "48px",
    "paddingTop": "18px",
    "paddingBottom": "18px",
    "gap": "24px"
  }
}
```

CI readback on latest head `74fa2b6`:

```text
Code standards & build (20): PASS
```