### PR TITLE
Fix sitemap hidden archives URL

### DIFF
--- a/src/utils/staticSitemap.ts
+++ b/src/utils/staticSitemap.ts
@@ -9,11 +9,19 @@ export const STATIC_SITEMAP_PATHS = ["", "about", "posts", "tags"] as const;
 
 export const REDIRECT_ONLY_SITEMAP_PATHS = ["sitemap-index.xml"] as const;
 
+export const HIDDEN_STATIC_SITEMAP_PATHS = ["archives"] as const;
+
 export const getStaticSitemapPaths = ({
   showArchives = true,
 }: {
   showArchives?: boolean;
-} = {}) => [...STATIC_SITEMAP_PATHS, ...(showArchives ? ["archives"] : [])];
+} = {}) =>
+  [...STATIC_SITEMAP_PATHS, ...(showArchives ? ["archives"] : [])].filter(
+    path =>
+      !HIDDEN_STATIC_SITEMAP_PATHS.includes(
+        path as (typeof HIDDEN_STATIC_SITEMAP_PATHS)[number]
+      )
+  );
 
 export const buildStaticSitemapXml = ({
   site = DEFAULT_SITE,

--- a/tests/crawlSignals.test.mjs
+++ b/tests/crawlSignals.test.mjs
@@ -9,6 +9,7 @@ import {
   getRobotsTxt,
 } from "../src/utils/crawlSignals.ts";
 import {
+  HIDDEN_STATIC_SITEMAP_PATHS,
   REDIRECT_ONLY_SITEMAP_PATHS,
   buildStaticSitemapXml,
   getStaticSitemapPaths,
@@ -85,16 +86,21 @@ test("canonical sitemap helper rejects bad site input instead of emitting invali
   assert.throws(() => getRobotsTxt("not a url"), /Invalid URL/);
 });
 
-test("static sitemap URL collection excludes redirect-only sitemap-index.xml", () => {
+test("static sitemap URL collection excludes redirect-only and hidden 404 surfaces", () => {
   const withArchives = getStaticSitemapPaths({ showArchives: true });
   const withoutArchives = getStaticSitemapPaths({ showArchives: false });
 
-  assert.deepEqual(withArchives, ["", "about", "posts", "tags", "archives"]);
+  assert.deepEqual(withArchives, ["", "about", "posts", "tags"]);
   assert.deepEqual(withoutArchives, ["", "about", "posts", "tags"]);
 
   for (const redirectPath of REDIRECT_ONLY_SITEMAP_PATHS) {
     assert.equal(withArchives.includes(redirectPath), false);
     assert.equal(withoutArchives.includes(redirectPath), false);
+  }
+
+  for (const hiddenPath of HIDDEN_STATIC_SITEMAP_PATHS) {
+    assert.equal(withArchives.includes(hiddenPath), false);
+    assert.equal(withoutArchives.includes(hiddenPath), false);
   }
 });
 
@@ -106,6 +112,7 @@ test("static sitemap XML includes canonical static pages and omits redirect/stal
 
   assert.match(xml, /<loc>https:\/\/berryhill\.dev\/<\/loc>/);
   assert.match(xml, /<loc>https:\/\/berryhill\.dev\/about\/<\/loc>/);
+  assert.doesNotMatch(xml, /<loc>https:\/\/berryhill\.dev\/archives\/<\/loc>/);
   assert.doesNotMatch(xml, /<loc>https:\/\/berryhill\.dev\/search\/<\/loc>/);
   assert.doesNotMatch(xml, /sitemap-index\.xml/);
   assert.doesNotMatch(xml, /pagefind/);


### PR DESCRIPTION
## Source issue

Closes #98

Issue: https://github.com/berryhill/bd-site/issues/98

## Classification / path boundary

- Classification: app/source-code-touching
- Path boundary: source utility + regression test only
- Changed files:
  - `src/utils/staticSitemap.ts`
  - `tests/crawlSignals.test.mjs`

## Prior PR audit / decision

- Checked all PR states for head `luca-vale:task-t_eb907b0-98`: no existing PR.
- Checked all PR states for head `luca-vale:feature/issue-98-bing-sitemap-errors`: no existing PR.
- Broader issue #98 search found no prior issue-98 PR to update; unrelated issue-number matches were already merged for other issues.
- Decision: open a clean replacement PR from `feature/issue-98-bing-sitemap-errors` to `main`.

## Summary of code changes

- Adds an explicit hidden static sitemap path guard in `src/utils/staticSitemap.ts`.
- Keeps `/archives/` out of `sitemap-static.xml` while the archives route intentionally returns 404.
- Preserves the rest of the static sitemap behavior, including canonical home/about/search/post list/tag surfaces.
- Updates crawl-surface tests so `/archives/` cannot be reintroduced into the static sitemap while it remains a hidden/404 route.

## Doc reconciliation actions

- Re-read repo onboarding/context surfaces during the flow, including `.otoxan/README.md`, `.otoxan/context.md`, `package.json`, `README.md`, `CLAUDE.md`, `src/config.ts`, `src/content.config.ts`, `src/live.config.ts`, and issue-specific sitemap/crawl files.
- Compared the implementation against the repo-local `.otoxan` rules and existing sitemap/crawl behavior.
- No human-facing docs required edits for this narrow bug fix; the behavior is captured in source and regression tests.

## Destructive-diff guard

Pre-push readback:

```text
git diff --name-status origin/main...HEAD
M	src/utils/staticSitemap.ts
M	tests/crawlSignals.test.mjs

git diff --stat origin/main...HEAD
 src/utils/staticSitemap.ts  | 10 +++++++++-
 tests/crawlSignals.test.mjs | 11 +++++++++--
 2 files changed, 18 insertions(+), 3 deletions(-)
```

No source/config/onboarding deletions. No `.github/workflows/*` changes.

Branch base readback before push:

```text
integration branch: main
origin/main: cbdcca9109d98ec0fba69e6b31647eb0eb6215bd
HEAD: a18a1ffec07f1a4c57c3677f90509e772f94776d
ahead/behind vs origin/main: 1 ahead / 1 behind
merge-base: 78de5801fb0ef4b47fa24e68fa80cd509effc8b2
```

The branch is one commit ahead with the sitemap fix and one commit behind current `origin/main`; no rebase/merge was performed during finalize.

## Test results

Delegate/local validation from implementation step:

```text
pnpm test              PASS
pnpm run lint          PASS
pnpm run format:check  PASS
pnpm run build         PASS
```

Auth/scope readback before push:

```text
gh auth status: authenticated as luca-vale
Token scopes include: repo, workflow
```
