### PR TITLE
Fix canonical URL duplication and crawl validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ pnpm run format:check # Check formatting without writing
   - Homepage `/og.png` uses `SITE.socialPreview` for headline, image alt, and cache version ownership; it should stay simplified around one berryhill.dev mark and restrained operator/shipped-systems/review-gates support copy.
   - Preserve post-specific previews: article pages use post-specific title/description/image metadata, custom `ogImage` values win, and eligible public posts without custom images use dynamic `/posts/<slug>/index.png` cards instead of the homepage card.
 - **URL Normalization**: [src/utils/url.ts](src/utils/url.ts) - Normalizes `SITE.website`, site-relative paths, post URLs, and post asset URLs to absolute URLs for post metadata and custom sitemap routes
+  - Canonical HTML routes use trailing slashes. `src/middleware.ts` permanently redirects non-canonical GET/HEAD HTML requests, while API and file-like paths (feeds, sitemap XML, assets, and generated images) are excluded.
+  - `normalizeCanonicalHtmlUrl`, redirect selection, and alternate-path helpers in `src/utils/url.ts` are the shared contract for middleware, layout metadata, and live crawl validation.
 - **Crawl Signals**: [src/utils/crawlSignals.ts](src/utils/crawlSignals.ts) - Shared source for canonical sitemap path, robots.txt crawler groups, generated asset disallow policy, the dedicated Twitterbot allow group, and Layout sitemap href. Preserve the Twitterbot `Allow: /` exception ahead of generic generated-image disallows so X can retrieve post pages and advertised PNG cards.
 - **Social Preview Readiness**: [src/utils/socialPreviewReadiness.ts](src/utils/socialPreviewReadiness.ts) - URL readiness gate for rendered social metadata, advertised PNG validity, and Twitterbot robots access to both the post URL and advertised image URL. Readiness responses include structured robots evidence; preserve that evidence when changing the gate.
 - **DuckDuckGo Crawl Signal**: [src/utils/duckDuckGoCrawlSignal.ts](src/utils/duckDuckGoCrawlSignal.ts) - Records DuckDuckGo coverage evidence through Bing/IndexNow success or canonical sitemap plus DuckDuckBot access; it is not a direct DuckDuckGo submission API
@@ -129,6 +131,7 @@ Search is powered by Pagefind, which indexes the built site and provides client-
 - **RSS Feed**: Generated at `/rss.xml` using `@astrojs/rss`
 - **Sitemap**: Custom SSR sitemap routes generate canonical crawler-facing `/sitemap.xml`, `/sitemap-static.xml` for helper-approved static pages only, and `/sitemap-posts.xml` for posts; `/sitemap-static.xml` excludes hidden/404-only surfaces such as `/archives/`, and `/sitemap-index.xml` redirects only for backward compatibility and should not be newly advertised
 - **Robots.txt**: Dynamically generated at `/robots.txt.ts` from shared crawlSignals rules, including explicit crawler groups, generated asset/index disallows, and the dedicated Twitterbot allow group that intentionally exempts X social-card retrieval from generic PNG disallows
+- **Canonical HTML redirects**: Middleware enforces one indexable trailing-slash URL per HTML page. Do not apply this policy to `/api`, extension-bearing routes, feeds, sitemap/robots files, assets, or generated images. The live `check:seo-crawl-surface` mode verifies sitemap `200`/indexability/self-canonical parity and permanent redirects from alternate slash variants.
 
 ## Important Notes
 

--- a/LLM_CRAWL_MANIFEST.md
+++ b/LLM_CRAWL_MANIFEST.md
@@ -13,7 +13,7 @@
   - `/sitemap-static.xml` - Real canonical static content pages only: `/`, `/about/`, `/posts/`, and `/tags/`. Redirect-only endpoints and hidden/404-only surfaces such as `/sitemap-index.xml` and `/archives/` are excluded.
   - `/sitemap-posts.xml` - Public blog posts only, excluding drafts, underscore/private paths, invalid or missing publish dates, and posts scheduled outside the configured margin.
   - `/sitemap-index.xml` - Backward-compatibility redirect only; not an advertised sitemap surface.
-- **URL normalization**: Static page `<loc>` values in `/sitemap-static.xml` and post `<loc>` values in `/sitemap-posts.xml` are normalized through the shared URL helper using `SITE.website`.
+- **URL normalization**: Static page `<loc>` values in `/sitemap-static.xml` and post `<loc>` values in `/sitemap-posts.xml` are normalized through the shared URL helper using `SITE.website`. HTML pages use one trailing-slash canonical shape; alternate slash variants permanently redirect instead of returning a second indexable `200`. API and file-like routes such as robots, sitemap XML, feeds, assets, and generated images retain their native behavior.
 - **Update Frequency**: Real-time (generated on-demand)
 - **Submission Status**:
   - Google Search Console: Sitemap resubmission is implemented for public post create/update when `GOOGLE_SEARCH_CONSOLE_ACCESS_TOKEN` is configured; operational Search Console property/token provisioning remains environment-dependent unless separately verified.
@@ -157,7 +157,8 @@ All structured data uses [Schema.org](https://schema.org) JSON-LD. The global `B
   - `<link rel="alternate" type="application/atom+xml">` in site layout
   - All pages advertise both RSS and Atom feeds for feed readers and LLM crawlers
 - **Open Graph / Twitter preview images**: ✅ Site-level `/og.png` and dynamic post `/posts/<slug>/index.png` use the shared terminal/operator brand template system, with metadata emitted as `summary_large_image` and absolute image URLs. Issue #127 keeps the homepage card simplified with one berryhill.dev brand mark, a separate site name and social headline, restrained operator/shipped-systems/review-gates support copy, a cache-versioned homepage image URL, complete image/png 1200x630 metadata, matching OG/Twitter alt text, and standards-correct Twitter `name` attributes. Article pages preserve post-specific titles and images, including custom `ogImage` behavior and dynamic post-card fallback. Issue #133 adds a dedicated Twitterbot robots exception and fail-closed readiness evidence so fresh X cards can retrieve both the post page and advertised PNG image even while generic/AI/search crawler groups continue to avoid generated-image noise.
-- **Canonical URLs**: ✅ Set on all pages; post canonical URLs are normalized through the shared URL helper
+- **Canonical URLs**: ✅ Set on all pages through the shared canonical HTML helper; sitemap HTML URLs are self-canonical and alternate slash variants permanently redirect to them
+- **Live canonical validation**: `pnpm run check:seo-crawl-surface -- --base-url https://berryhill.dev/` checks each sitemap HTML URL for `200`, indexability, canonical/OG parity, and redirect-only alternate variants. This validates repository-controlled crawl signals; it does not guarantee Google's indexing selection.
 - **Post URL normalization**: ✅ Post canonical, OG image, and JSON-LD URL fields share the same `SITE.website` normalization path
 - **Meta Descriptions**: ✅ Unique per page
 

--- a/README.md
+++ b/README.md
@@ -104,11 +104,14 @@ pnpm run format
 # Crawl/search visibility validation
 pnpm run check:search-visibility
 pnpm run check:seo-crawl-surface
+pnpm run check:seo-crawl-surface -- --base-url https://berryhill.dev/
 ```
 
 `pnpm run check:search-visibility` checks robots.txt, canonical `/sitemap.xml`, rss.xml, llms.txt, and representative JSON-LD.
 
 `pnpm run check:seo-crawl-surface` validates local source and built crawl surfaces, including public post links, sitemap/canonical/feed URL shape, search noindex behavior, and legacy title-quality advisories.
+
+The URL-based crawl audit verifies every HTML URL advertised by the live sitemap: the canonical URL must remain `200`, indexable, and self-canonical, while its non-canonical slash variant must return a permanent redirect. HTML routes use trailing slashes; file-like routes, feeds, sitemap XML, API routes, assets, and generated images keep their native URL behavior. A passing repository audit confirms the site's crawl contract, not Google's eventual indexing decision.
 
 ## 🐳 Docker
 

--- a/scripts/checkSeoCrawlSurface.mjs
+++ b/scripts/checkSeoCrawlSurface.mjs
@@ -7,7 +7,12 @@ import matter from "gray-matter";
 import { SITE } from "../src/config.ts";
 import { getRobotsTxt } from "../src/utils/crawlSignals.ts";
 import { buildStaticSitemapXml } from "../src/utils/staticSitemap.ts";
-import { normalizeSiteWebsite, toAbsoluteSiteUrl } from "../src/utils/url.ts";
+import {
+  getAlternateHtmlPathname,
+  normalizeCanonicalHtmlUrl,
+  normalizeSiteWebsite,
+  toAbsoluteSiteUrl,
+} from "../src/utils/url.ts";
 import { auditPostTitleQuality } from "../src/utils/postTitleQuality.ts";
 
 const DEFAULT_BASE_URL = normalizeSiteWebsite(SITE.website);
@@ -279,6 +284,27 @@ async function fetchText(url) {
   return { text, finalUrl: response.url, contentType: response.headers.get("content-type") ?? "" };
 }
 
+async function fetchWithoutRedirect(url) {
+  const response = await fetch(url, {
+    redirect: "manual",
+    headers: { "User-Agent": "berryhill-dev-seo-crawl-surface-check/1.0" },
+  });
+  return {
+    status: response.status,
+    location: response.headers.get("location"),
+    contentType: response.headers.get("content-type") ?? "",
+  };
+}
+
+function isIndexableHtml(html) {
+  return !/<meta\s+name=["']robots["']\s+content=["'][^"']*noindex/i.test(html);
+}
+
+function resolveRedirectLocation(location, fromUrl) {
+  if (!location) return null;
+  return new URL(location, fromUrl).href;
+}
+
 async function auditLiveCrawlSurface(baseUrl) {
   const issues = [];
   const base = normalizeSiteWebsite(baseUrl);
@@ -310,17 +336,43 @@ async function auditLiveCrawlSurface(baseUrl) {
       const { text } = await fetchText(loc);
       const childLocs = extractXmlLocs(text);
       issues.push(...auditUrlInvariants(childLocs, { expectedOrigin, label: `${loc} loc` }));
-      for (const childLoc of childLocs.filter(url => /\/posts\//.test(new URL(url).pathname))) {
-        const { text: html } = await fetchText(childLoc);
+      for (const childLoc of childLocs) {
+        const childUrl = new URL(childLoc);
+        const expected = normalizeCanonicalHtmlUrl(childUrl.pathname, DEFAULT_BASE_URL).href;
+        const { text: html, finalUrl, contentType } = await fetchText(childLoc);
         const canonical = extractAttr(html, /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i);
         const ogUrl = extractAttr(html, /<meta[^>]+property=["']og:url["'][^>]+content=["']([^"']+)["']/i);
-        const expected = new URL(new URL(childLoc).pathname, DEFAULT_BASE_URL).href;
-        if (canonical !== expected || ogUrl !== expected) {
-          addIssue(issues, "Live canonical and OG URL disagree with sitemap loc", {
+
+        if (finalUrl !== expected || canonical !== expected || ogUrl !== expected) {
+          addIssue(issues, "Live sitemap HTML URL is not self-canonical", {
             loc: childLoc,
             expected,
+            finalUrl,
+            contentType,
             canonical,
             ogUrl,
+          });
+        }
+
+        if (!isIndexableHtml(html)) {
+          addIssue(issues, "Live sitemap HTML URL is not indexable", { loc: childLoc });
+        }
+
+        const alternatePathname = getAlternateHtmlPathname(childUrl.pathname);
+        if (!alternatePathname) continue;
+
+        const alternateUrl = new URL(alternatePathname, childLoc).href;
+        const alternateResponse = await fetchWithoutRedirect(alternateUrl);
+        const redirectedTo = resolveRedirectLocation(alternateResponse.location, alternateUrl);
+        if (![301, 308].includes(alternateResponse.status) || redirectedTo !== expected) {
+          addIssue(issues, "Live alternate HTML URL does not redirect to canonical sitemap URL", {
+            loc: childLoc,
+            alternateUrl,
+            expected,
+            status: alternateResponse.status,
+            location: alternateResponse.location,
+            redirectedTo,
+            contentType: alternateResponse.contentType,
           });
         }
       }

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -7,6 +7,7 @@ import {
 import { SITE } from "@/config";
 import { getLayoutSitemapHref } from "@/utils/crawlSignals";
 import { normalizeGa4ArticlePath } from "@/utils/ga4EditorialMapping";
+import { normalizeCanonicalHtmlUrl } from "@/utils/url";
 import "@/styles/global.css";
 
 export interface Props {
@@ -47,7 +48,8 @@ const {
 } = Astro.props;
 
 const currentPageURL = new URL(Astro.url.pathname, Astro.url);
-const canonicalPageURL = new URL(canonicalURL, Astro.url);
+const canonicalPageURL = normalizeCanonicalHtmlUrl(canonicalURL, Astro.url);
+const canonicalURLHref = canonicalPageURL.href;
 const isHomepage = canonicalPageURL.pathname === "/";
 const resolvedSocialTitle =
   socialTitle ?? (isHomepage ? SITE.socialPreview.title : title);
@@ -118,7 +120,7 @@ if (!window.__bdGa4PageviewListenerInstalled) {
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/png" href="/favicon.png" />
     <link rel="apple-touch-icon" href="/favicon.png" />
-    <link rel="canonical" href={canonicalURL} />
+    <link rel="canonical" href={canonicalURLHref} />
     <meta name="generator" content={Astro.generator} />
 
     <!-- General Meta Tags -->
@@ -134,7 +136,7 @@ if (!window.__bdGa4PageviewListenerInstalled) {
     <meta property="og:site_name" content={SITE.title} />
     <meta property="og:title" content={resolvedSocialTitle} />
     <meta property="og:description" content={resolvedSocialDescription} />
-    <meta property="og:url" content={canonicalURL} />
+    <meta property="og:url" content={canonicalURLHref} />
     <meta property="og:image" content={socialImageURL} />
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:width" content="1200" />
@@ -161,7 +163,7 @@ if (!window.__bdGa4PageviewListenerInstalled) {
 
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:url" content={canonicalURL} />
+    <meta name="twitter:url" content={canonicalURLHref} />
     <meta name="twitter:title" content={resolvedSocialTitle} />
     <meta name="twitter:description" content={resolvedSocialDescription} />
     <meta name="twitter:image" content={socialImageURL} />

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,18 @@
+import { defineMiddleware } from "astro:middleware";
+import { getCanonicalHtmlRedirectLocation } from "@/utils/url";
+
+const REDIRECT_STATUS = 301;
+
+export const onRequest = defineMiddleware((context, next) => {
+  const redirectLocation = getCanonicalHtmlRedirectLocation(
+    context.request.method,
+    context.request.url,
+    context.request.headers.get("accept")
+  );
+
+  if (!redirectLocation) {
+    return next();
+  }
+
+  return context.redirect(redirectLocation, REDIRECT_STATUS);
+});

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,4 +1,6 @@
 const DEFAULT_WEBSITE = "https://berryhill.dev/";
+const FILE_EXTENSION_PATH_RE = /\/[^/]+\.[^/]+$/;
+const CANONICAL_HTML_REDIRECT_METHODS = new Set(["GET", "HEAD"]);
 
 function isBlank(
   value: string | null | undefined
@@ -6,8 +8,8 @@ function isBlank(
   return value === null || value === undefined || value.trim() === "";
 }
 
-function toSiteBaseUrl(website: string): URL {
-  if (isBlank(website)) {
+function toSiteBaseUrl(website: string | URL): URL {
+  if (typeof website === "string" && isBlank(website)) {
     throw new TypeError("SITE.website must be a non-empty absolute URL");
   }
 
@@ -20,6 +22,95 @@ function toSiteBaseUrl(website: string): URL {
 
 function ensureTrailingSlash(pathname: string) {
   return pathname.endsWith("/") ? pathname : `${pathname}/`;
+}
+
+function isApiPath(pathname: string) {
+  return pathname === "/api" || pathname.startsWith("/api/");
+}
+
+export function isFileLikePathname(pathname: string): boolean {
+  return FILE_EXTENSION_PATH_RE.test(pathname);
+}
+
+export function shouldEnforceTrailingSlash(pathname: string): boolean {
+  return (
+    pathname !== "/" &&
+    !pathname.endsWith("/") &&
+    !isApiPath(pathname) &&
+    !isFileLikePathname(pathname)
+  );
+}
+
+export function getAlternateHtmlPathname(pathname: string): string | null {
+  if (pathname === "/" || isApiPath(pathname) || isFileLikePathname(pathname)) {
+    return null;
+  }
+
+  return pathname.endsWith("/")
+    ? pathname.replace(/\/+$/, "")
+    : ensureTrailingSlash(pathname);
+}
+
+export function normalizeCanonicalHtmlUrl(
+  pathOrUrl: string | URL,
+  base: string | URL = DEFAULT_WEBSITE
+): URL {
+  const url = new URL(pathOrUrl, toSiteBaseUrl(base));
+
+  if (shouldEnforceTrailingSlash(url.pathname)) {
+    url.pathname = ensureTrailingSlash(url.pathname);
+  }
+
+  return url;
+}
+
+export function acceptsHtmlResponse(
+  acceptHeader: string | null | undefined
+): boolean {
+  if (isBlank(acceptHeader)) return true;
+
+  return acceptHeader.split(",").some(value => {
+    const [mimeType = "", ...params] = value.split(";");
+    const q = params
+      .map(param => param.trim().match(/^q=(\d*(?:\.\d+)?)$/i)?.[1])
+      .find(Boolean);
+
+    if (q !== undefined && Number(q) <= 0) {
+      return false;
+    }
+
+    const normalizedMimeType = mimeType.trim().toLowerCase();
+    return (
+      normalizedMimeType === "text/html" ||
+      normalizedMimeType === "application/xhtml+xml" ||
+      normalizedMimeType === "text/*" ||
+      normalizedMimeType === "*/*"
+    );
+  });
+}
+
+export function getCanonicalHtmlRedirectLocation(
+  method: string,
+  requestUrl: string | URL,
+  acceptHeader?: string | null,
+  base: string | URL = DEFAULT_WEBSITE
+): string | null {
+  if (!CANONICAL_HTML_REDIRECT_METHODS.has(method.toUpperCase())) {
+    return null;
+  }
+
+  if (!acceptsHtmlResponse(acceptHeader)) {
+    return null;
+  }
+
+  const url = new URL(requestUrl, toSiteBaseUrl(base));
+  const canonicalUrl = normalizeCanonicalHtmlUrl(url, base);
+
+  if (canonicalUrl.pathname === url.pathname) {
+    return null;
+  }
+
+  return `${canonicalUrl.pathname}${canonicalUrl.search}${canonicalUrl.hash}`;
 }
 
 export function normalizeSiteWebsite(website = DEFAULT_WEBSITE): string {

--- a/tests/url.test.mjs
+++ b/tests/url.test.mjs
@@ -1,7 +1,12 @@
 /* eslint-disable no-console */
 import assert from "node:assert/strict";
 import {
+  acceptsHtmlResponse,
+  getAlternateHtmlPathname,
+  getCanonicalHtmlRedirectLocation,
+  normalizeCanonicalHtmlUrl,
   normalizeSiteWebsite,
+  shouldEnforceTrailingSlash,
   toAbsoluteSiteUrl,
   toPostAssetUrl,
   toPostUrl,
@@ -68,6 +73,101 @@ test("preserves already-absolute OG and canonical URLs", () => {
   assert.equal(
     toPostUrl("https://example.com/canonical-post", "https://berryhill.dev/"),
     "https://example.com/canonical-post/"
+  );
+});
+
+test("canonical HTML URLs enforce trailing slashes for route-like paths", () => {
+  assert.equal(
+    normalizeCanonicalHtmlUrl("/about", "https://berryhill.dev/").href,
+    "https://berryhill.dev/about/"
+  );
+  assert.equal(
+    normalizeCanonicalHtmlUrl("https://berryhill.dev/posts/example?utm=1#top").href,
+    "https://berryhill.dev/posts/example/?utm=1#top"
+  );
+  assert.equal(
+    normalizeCanonicalHtmlUrl("/", "https://berryhill.dev/").href,
+    "https://berryhill.dev/"
+  );
+});
+
+test("trailing slash enforcement excludes APIs, XML feeds, assets, and generated images", () => {
+  assert.equal(shouldEnforceTrailingSlash("/api/posts"), false);
+  assert.equal(shouldEnforceTrailingSlash("/robots.txt"), false);
+  assert.equal(shouldEnforceTrailingSlash("/sitemap.xml"), false);
+  assert.equal(shouldEnforceTrailingSlash("/rss.xml"), false);
+  assert.equal(shouldEnforceTrailingSlash("/assets/blog/example/diagram.svg"), false);
+  assert.equal(shouldEnforceTrailingSlash("/posts/example/index.png"), false);
+  assert.equal(shouldEnforceTrailingSlash("/about"), true);
+});
+
+test("HTML alternate path detection ignores non-HTML crawl surfaces", () => {
+  assert.equal(getAlternateHtmlPathname("/about/"), "/about");
+  assert.equal(getAlternateHtmlPathname("/about"), "/about/");
+  assert.equal(getAlternateHtmlPathname("/"), null);
+  assert.equal(getAlternateHtmlPathname("/api/posts"), null);
+  assert.equal(getAlternateHtmlPathname("/rss.xml"), null);
+  assert.equal(getAlternateHtmlPathname("/posts/example/index.png"), null);
+});
+
+test("canonical HTML redirect helper redirects GET and HEAD route-like paths", () => {
+  assert.equal(
+    getCanonicalHtmlRedirectLocation(
+      "GET",
+      "https://berryhill.dev/posts/example?utm_source=test",
+      "text/html"
+    ),
+    "/posts/example/?utm_source=test"
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation(
+      "HEAD",
+      "https://berryhill.dev/about#team",
+      "text/html,application/xhtml+xml"
+    ),
+    "/about/#team"
+  );
+});
+
+test("canonical HTML redirect helper passes through non-GET and non-HTML requests", () => {
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("POST", "https://berryhill.dev/about", "text/html"),
+    null
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("PUT", "https://berryhill.dev/about", "*/*"),
+    null
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/about", "application/json"),
+    null
+  );
+  assert.equal(acceptsHtmlResponse("application/json, image/png"), false);
+  assert.equal(acceptsHtmlResponse("text/html;q=0, application/json"), false);
+  assert.equal(acceptsHtmlResponse("text/*;q=0.8, application/json"), true);
+  assert.equal(acceptsHtmlResponse(null), true);
+});
+
+test("canonical HTML redirect helper excludes canonical, API, and file-like paths", () => {
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/about/", "text/html"),
+    null
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/api/posts", "text/html"),
+    null
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/rss.xml", "text/html"),
+    null
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/assets/blog/post/figure.svg", "*/*"),
+    null
+  );
+  assert.equal(
+    getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/posts/example/index.png", "*/*"),
+    null
   );
 });
 


### PR DESCRIPTION
## Source issue

Closes #136

https://github.com/berryhill/bd-site/issues/136

## Classification

- Path boundary: app/source-code-touching
- Intake: crawl/indexing correctness bug with documentation reconciliation

## Prior PR audit

Searched all PR states by issue reference and by head branch immediately before push. No prior PR exists for issue #136 or `feature/issue-136-canonical-url-crawl-validation`, so this is the clean initial PR rather than a replacement.

## Summary

- Enforces one trailing-slash canonical URL for route-like HTML GET/HEAD requests through Astro middleware.
- Excludes `/api` and extension-bearing routes so robots, sitemap XML, feeds, assets, and generated images keep their native behavior.
- Normalizes canonical, Open Graph, and Twitter URLs through the shared HTML URL helper.
- Extends the live SEO crawl audit to require sitemap HTML URLs to be 200, indexable, and self-canonical, with alternate slash variants permanently redirecting to the canonical URL.
- Adds focused URL, Accept-header, method, API, feed, asset, and generated-image regression coverage.

## Documentation reconciliation

- Updated `README.md` with the supported live crawl-audit command and the boundary between repository crawl correctness and external Google indexing decisions.
- Updated `CLAUDE.md` with middleware, URL-helper, exclusion, and validation contracts for future agents.
- Updated `LLM_CRAWL_MANIFEST.md` with canonical trailing-slash and live validation behavior.
- No new canonical-URL document was created; existing authoritative docs were reconciled in place.

## Destructive-diff guard

- Compared `origin/main...HEAD` after a fresh fetch.
- Ahead/behind: 2 ahead, 0 behind.
- Changed paths: 8.
- Existing files deleted: 0.
- Workflow files changed: 0.
- Diff stat: 284 insertions, 14 deletions.
- `git diff --check origin/main...HEAD`: clean.

## Validation

- `pnpm test` — passed (all scoped suites; local SEO audit passed with 3 pre-existing legacy title advisories).
- `pnpm run lint` — passed.
- `pnpm run format:check` — passed after source and documentation commits.
- `pnpm run build` — passed.
- `pnpm exec prettier --check README.md CLAUDE.md LLM_CRAWL_MANIFEST.md` — passed.

## Deployment follow-up

After merge and deployment, run `pnpm run check:seo-crawl-surface -- --base-url https://berryhill.dev/`, verify the full sitemap and alternate URL surface, then resubmit `/sitemap.xml` and start a new Search Console validation. A green repository/deployment audit does not guarantee the later Google indexing selection.