### PR TITLE
fix(seo): consolidate page-one archive aliases

### DIFF
--- a/scripts/checkSeoCrawlSurface.mjs
+++ b/scripts/checkSeoCrawlSurface.mjs
@@ -233,6 +233,17 @@ export async function auditLocalCrawlSurface({ contentDir = "src/data/blog", dis
     )
   );
 
+  const pageOneAliases = ["/posts/page/1", "/posts/page/1/"];
+  for (const alias of pageOneAliases) {
+    const absoluteAlias = toAbsoluteSiteUrl(alias, DEFAULT_BASE_URL, { trailingSlash: true });
+    if (sitemapLocs.some(loc => loc === absoluteAlias || loc.replace(/\/$/, "") === absoluteAlias.replace(/\/$/, ""))) {
+      addIssue(issues, "Static sitemap advertises a page-one archive alias", {
+        alias,
+        absoluteAlias,
+      });
+    }
+  }
+
   const robots = getRobotsTxt(DEFAULT_BASE_URL);
   const sitemapDirective = robots.match(/^Sitemap:\s*(\S+)/m)?.[1];
   if (sitemapDirective !== new URL("sitemap.xml", DEFAULT_BASE_URL).href) {
@@ -274,6 +285,25 @@ export async function auditLocalCrawlSurface({ contentDir = "src/data/blog", dis
   };
 }
 
+export function auditPageOneArchiveAliasesStatic({
+  expectedCanonical = new URL("/posts/", DEFAULT_BASE_URL).href,
+} = {}) {
+  return [
+    {
+      alias: "/posts/page/1",
+      expectedCanonical,
+      expectedStatus: 301,
+      expectedRedirectTarget: expectedCanonical,
+    },
+    {
+      alias: "/posts/page/1/",
+      expectedCanonical,
+      expectedStatus: 301,
+      expectedRedirectTarget: expectedCanonical,
+    },
+  ];
+}
+
 async function fetchText(url) {
   const response = await fetch(url, {
     redirect: "follow",
@@ -284,8 +314,9 @@ async function fetchText(url) {
   return { text, finalUrl: response.url, contentType: response.headers.get("content-type") ?? "" };
 }
 
-async function fetchWithoutRedirect(url) {
+async function fetchWithoutRedirect(url, { method = "GET" } = {}) {
   const response = await fetch(url, {
+    method,
     redirect: "manual",
     headers: { "User-Agent": "berryhill-dev-seo-crawl-surface-check/1.0" },
   });
@@ -303,6 +334,70 @@ function isIndexableHtml(html) {
 function resolveRedirectLocation(location, fromUrl) {
   if (!location) return null;
   return new URL(location, fromUrl).href;
+}
+
+const PAGE_ONE_ALIASES = ["/posts/page/1", "/posts/page/1/"];
+
+async function auditPageOneArchiveAliases(base, issues) {
+  const methods = ["GET", "HEAD"];
+  const expectedCanonical = new URL("/posts/", base).href;
+
+  for (const alias of PAGE_ONE_ALIASES) {
+    for (const method of methods) {
+      const aliasUrl = new URL(alias, base).href;
+      const response = await fetchWithoutRedirect(aliasUrl, { method });
+      const redirectedTo = resolveRedirectLocation(response.location, aliasUrl);
+
+      if (response.status !== 301 || redirectedTo !== expectedCanonical) {
+        addIssue(issues, "Live page-one archive alias does not 301 directly to /posts/", {
+          alias,
+          method,
+          status: response.status,
+          location: response.location,
+          redirectedTo,
+          expected: expectedCanonical,
+          contentType: response.contentType,
+        });
+      }
+    }
+  }
+
+  const canonicalResponse = await fetchWithoutRedirect(expectedCanonical);
+  if (canonicalResponse.status !== 200) {
+    addIssue(issues, "Live /posts/ did not return 200", {
+      url: expectedCanonical,
+      status: canonicalResponse.status,
+      contentType: canonicalResponse.contentType,
+    });
+  }
+
+  try {
+    const { text: canonicalHtml, finalUrl: canonicalFinalUrl } = await fetchText(expectedCanonical);
+    if (canonicalFinalUrl !== expectedCanonical) {
+      addIssue(issues, "Live /posts/ did not resolve as self-canonical", {
+        url: expectedCanonical,
+        finalUrl: canonicalFinalUrl,
+      });
+    }
+    const canonical = extractAttr(canonicalHtml, /<link[^>]+rel=["']canonical["'][^>]+href=["']([^"']+)["']/i);
+    const ogUrl = extractAttr(canonicalHtml, /<meta[^>]+property=["']og:url["'][^>]+content=["']([^"']+)["']/i);
+    if (canonical !== expectedCanonical || ogUrl !== expectedCanonical) {
+      addIssue(issues, "Live /posts/ canonical or og:url disagrees with self", {
+        url: expectedCanonical,
+        canonical,
+        ogUrl,
+        expected: expectedCanonical,
+      });
+    }
+    if (!isIndexableHtml(canonicalHtml)) {
+      addIssue(issues, "Live /posts/ is not indexable", { url: expectedCanonical });
+    }
+  } catch (error) {
+    addIssue(issues, "Live /posts/ canonical fetch failed", {
+      url: expectedCanonical,
+      error: error.message,
+    });
+  }
 }
 
 async function auditLiveCrawlSurface(baseUrl) {
@@ -385,6 +480,8 @@ async function auditLiveCrawlSurface(baseUrl) {
   if (!/<meta\s+name=["']robots["']\s+content=["'][^"']*noindex/i.test(searchHtml)) {
     addIssue(issues, "Live search page is missing robots noindex meta", { route: "/search/" });
   }
+
+  await auditPageOneArchiveAliases(base, issues);
 
   for (const [surfacePath, { text }] of fetched) {
     if (!["/rss.xml", "/atom.xml"].includes(surfacePath)) continue;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,13 +1,30 @@
 import { defineMiddleware } from "astro:middleware";
-import { getCanonicalHtmlRedirectLocation } from "@/utils/url";
+import {
+  getCanonicalHtmlRedirectLocation,
+  getPageOneArchiveRedirectLocation,
+} from "@/utils/url";
 
 const REDIRECT_STATUS = 301;
 
 export const onRequest = defineMiddleware((context, next) => {
+  const method = context.request.method;
+  const requestUrl = context.request.url;
+  const acceptHeader = context.request.headers.get("accept");
+
+  const pageOneRedirect = getPageOneArchiveRedirectLocation(
+    method,
+    requestUrl,
+    acceptHeader
+  );
+
+  if (pageOneRedirect) {
+    return context.redirect(pageOneRedirect, REDIRECT_STATUS);
+  }
+
   const redirectLocation = getCanonicalHtmlRedirectLocation(
-    context.request.method,
-    context.request.url,
-    context.request.headers.get("accept")
+    method,
+    requestUrl,
+    acceptHeader
   );
 
   if (!redirectLocation) {

--- a/src/pages/posts/page/[page].astro
+++ b/src/pages/posts/page/[page].astro
@@ -9,9 +9,14 @@ import { SITE } from "@/config";
 import { buildCollectionPageJsonLd } from "@/utils/structuredData";
 
 const { page: pageParam } = Astro.params;
-const currentPage = parseInt(pageParam);
-if (isNaN(currentPage) || !pageParam.match(/^\d+$/)) {
+if (!pageParam.match(/^[1-9]\d*$/)) {
   return new Response(null, { status: 404 });
+}
+const currentPage = Number(pageParam);
+
+if (pageParam === "1") {
+  const target = `/posts/${Astro.url.search}${Astro.url.hash}`;
+  return Astro.redirect(target, 301);
 }
 
 const { entries: allPosts } = await getLiveCollection("liveBlog");

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,8 @@
 const DEFAULT_WEBSITE = "https://berryhill.dev/";
 const FILE_EXTENSION_PATH_RE = /\/[^/]+\.[^/]+$/;
 const CANONICAL_HTML_REDIRECT_METHODS = new Set(["GET", "HEAD"]);
+const PAGE_ONE_ARCHIVE_PATH_RE = /^\/posts\/page\/1\/?$/;
+const PAGE_ONE_ARCHIVE_TARGET = "/posts/";
 
 function isBlank(
   value: string | null | undefined
@@ -111,6 +113,29 @@ export function getCanonicalHtmlRedirectLocation(
   }
 
   return `${canonicalUrl.pathname}${canonicalUrl.search}${canonicalUrl.hash}`;
+}
+
+export function getPageOneArchiveRedirectLocation(
+  method: string,
+  requestUrl: string | URL,
+  acceptHeader?: string | null,
+  base: string | URL = DEFAULT_WEBSITE
+): string | null {
+  if (!CANONICAL_HTML_REDIRECT_METHODS.has(method.toUpperCase())) {
+    return null;
+  }
+
+  if (!acceptsHtmlResponse(acceptHeader)) {
+    return null;
+  }
+
+  const url = new URL(requestUrl, toSiteBaseUrl(base));
+
+  if (!PAGE_ONE_ARCHIVE_PATH_RE.test(url.pathname)) {
+    return null;
+  }
+
+  return `${PAGE_ONE_ARCHIVE_TARGET}${url.search}${url.hash}`;
 }
 
 export function normalizeSiteWebsite(website = DEFAULT_WEBSITE): string {

--- a/tests/seoCrawlSurface.test.mjs
+++ b/tests/seoCrawlSurface.test.mjs
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   auditInternalPostLinks,
   auditLocalCrawlSurface,
+  auditPageOneArchiveAliasesStatic,
   auditPublishedPostTitleQuality,
   extractXmlLocs,
   isMalformedCrawlUrl,
@@ -187,6 +188,31 @@ test("local audit reports legacy title quality as advisory without failing issue
       assert.equal(result.issues.length, 0);
       assert.equal(result.titleQualityAdvisories.length, advisories.length);
       assert.equal(result.checked.titleQualityAdvisories, advisories.length);
+    }
+  );
+});
+
+test("page-one archive alias contract lists both aliases with /posts/ canonical target", () => {
+  const contract = auditPageOneArchiveAliasesStatic();
+  assert.deepEqual(contract.map(entry => entry.alias), ["/posts/page/1", "/posts/page/1/"]);
+  for (const entry of contract) {
+    assert.equal(entry.expectedCanonical, "https://berryhill.dev/posts/");
+    assert.equal(entry.expectedStatus, 301);
+    assert.equal(entry.expectedRedirectTarget, "https://berryhill.dev/posts/");
+  }
+});
+
+test("local audit confirms the static sitemap does not advertise page-one archive aliases", async () => {
+  await withTempContent(
+    {
+      "published.md": markdown({ title: "Published" }),
+    },
+    async contentDir => {
+      const result = await auditLocalCrawlSurface({ contentDir, distDir: path.join(contentDir, "missing-dist") });
+      const aliasIssues = result.issues.filter(issue =>
+        issue.message === "Static sitemap advertises a page-one archive alias"
+      );
+      assert.equal(aliasIssues.length, 0, "real static sitemap should not advertise either page-one alias");
     }
   );
 });

--- a/tests/url.test.mjs
+++ b/tests/url.test.mjs
@@ -4,6 +4,7 @@ import {
   acceptsHtmlResponse,
   getAlternateHtmlPathname,
   getCanonicalHtmlRedirectLocation,
+  getPageOneArchiveRedirectLocation,
   normalizeCanonicalHtmlUrl,
   normalizeSiteWebsite,
   shouldEnforceTrailingSlash,
@@ -169,6 +170,127 @@ test("canonical HTML redirect helper excludes canonical, API, and file-like path
     getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/posts/example/index.png", "*/*"),
     null
   );
+});
+
+test("page-one archive redirect sends both GET and HEAD for /posts/page/1 and /posts/page/1/ directly to /posts/", () => {
+  assert.equal(
+    getPageOneArchiveRedirectLocation(
+      "GET",
+      "https://berryhill.dev/posts/page/1",
+      "text/html"
+    ),
+    "/posts/"
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation(
+      "HEAD",
+      "https://berryhill.dev/posts/page/1",
+      "text/html"
+    ),
+    "/posts/"
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation(
+      "GET",
+      "https://berryhill.dev/posts/page/1/",
+      "text/html"
+    ),
+    "/posts/"
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation(
+      "HEAD",
+      "https://berryhill.dev/posts/page/1/",
+      "text/html"
+    ),
+    "/posts/"
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation(
+      "GET",
+      "https://berryhill.dev/posts/page/1?utm_source=test#top",
+      "text/html"
+    ),
+    "/posts/?utm_source=test#top"
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation(
+      "GET",
+      "https://berryhill.dev/posts/page/1/",
+      "*/*"
+    ),
+    "/posts/"
+  );
+});
+
+test("page-one archive redirect is a single hop: target is /posts/ not /posts/page/1 or /posts/page/1/", () => {
+  const noSlash = getPageOneArchiveRedirectLocation(
+    "GET",
+    "https://berryhill.dev/posts/page/1",
+    "text/html"
+  );
+  const slashed = getPageOneArchiveRedirectLocation(
+    "GET",
+    "https://berryhill.dev/posts/page/1/",
+    "text/html"
+  );
+
+  assert.notEqual(noSlash, "/posts/page/1/");
+  assert.notEqual(slashed, "/posts/page/1/");
+  assert.notEqual(noSlash, "/posts/page/1");
+  assert.notEqual(slashed, "/posts/page/1");
+  assert.equal(noSlash, slashed);
+  assert.equal(noSlash, "/posts/");
+});
+
+test("page-one archive redirect passes through non-GET/HEAD requests and non-HTML accepts", () => {
+  assert.equal(
+    getPageOneArchiveRedirectLocation("POST", "https://berryhill.dev/posts/page/1", "text/html"),
+    null
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation("PUT", "https://berryhill.dev/posts/page/1/", "text/html"),
+    null
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation("DELETE", "https://berryhill.dev/posts/page/1", "*/*"),
+    null
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation("GET", "https://berryhill.dev/posts/page/1", "application/json"),
+    null
+  );
+  assert.equal(
+    getPageOneArchiveRedirectLocation("GET", "https://berryhill.dev/posts/page/1/", "text/html;q=0"),
+    null
+  );
+});
+
+test("page-one archive redirect ignores non-page-one archive paths and other routes", () => {
+  for (const path of [
+    "https://berryhill.dev/posts/",
+    "https://berryhill.dev/posts/page/2",
+    "https://berryhill.dev/posts/page/2/",
+    "https://berryhill.dev/posts/page/3/",
+    "https://berryhill.dev/posts/page/16/",
+    "https://berryhill.dev/posts/page/0",
+    "https://berryhill.dev/posts/page/0/",
+    "https://berryhill.dev/posts/page/-1",
+    "https://berryhill.dev/posts/page/-1/",
+    "https://berryhill.dev/posts/page/01",
+    "https://berryhill.dev/posts/page/01/",
+    "https://berryhill.dev/posts/page/abc",
+    "https://berryhill.dev/posts/example/",
+    "https://berryhill.dev/about/",
+    "https://berryhill.dev/",
+    "https://berryhill.dev/posts/page/1/index.html",
+  ]) {
+    assert.equal(
+      getPageOneArchiveRedirectLocation("GET", path, "text/html"),
+      null,
+      path
+    );
+  }
 });
 
 test("throws for invalid URL inputs", () => {


### PR DESCRIPTION
## Summary

- Permanently redirects both `/posts/page/1` and `/posts/page/1/` directly to `/posts/` for GET and HEAD requests.
- Keeps page 2+ trailing-slash normalization and malformed/out-of-range 404 behavior intact.
- Extends the reusable SEO crawl audit so future live checks fail if either page-one alias reappears as an indexable URL or redirect chain.

Closes #139

## Acceptance contract

- [x] Both page-one aliases issue one direct `301` to `/posts/` for GET and HEAD.
- [x] `/posts/` remains `200`, indexable, self-canonical, and aligned with `og:url`.
- [x] `/posts/page/2` continues to normalize to `/posts/page/2/`; populated page 2 remains self-canonical.
- [x] Malformed, zero, negative, leading-zero, and out-of-range pagination remains `404`.
- [x] Sitemap output does not advertise either page-one alias.
- [x] Tests cover both aliases, both methods, direct-target/no-chain behavior, and page 2+ regressions.

## Changed surfaces

- `src/utils/url.ts` — exact page-one alias redirect helper.
- `src/middleware.ts` — semantic redirect runs before generic slash normalization.
- `src/pages/posts/page/[page].astro` — defensive route-level page-one redirect and strict positive-integer parsing.
- `scripts/checkSeoCrawlSurface.mjs` — static sitemap guard and live GET/HEAD alias/canonical audit.
- `tests/url.test.mjs` and `tests/seoCrawlSurface.test.mjs` — regression coverage.

Path boundary: **app/source-code-touching**

## Validation

- `pnpm test` — passed; three pre-existing legacy title-length advisories remained non-failing.
- `pnpm run lint` — passed.
- `pnpm run format:check` — passed.
- `pnpm run build` — passed.
- Local SSR readback verified both aliases return direct `301 Location: /posts/` for GET and HEAD, `/posts/` remains `200`/indexable/self-canonical with matching `og:url`, page 2 behavior is unchanged, and malformed/out-of-range routes return `404`.
- `node scripts/checkSeoCrawlSurface.mjs --base-url https://berryhill.dev` is intentionally a post-deploy gate: production still exposes the pre-fix behavior until this PR is merged and deployed.

Visual evidence: not applicable; this is a URL/crawl behavior change with no rendered design change.

## Prior-attempt lineage

- Earlier queued task `t_de47bfc` used branch `feature/issue-139-page-one-indexing` but did not produce an owned open PR.
- This PR is the clean task-owned pass from `origin/main@8eef9160283f0a4630013c9e1896c4f1a3d60a88`; no prior branch or rejected PR was reused.
- Active implementation lineage: task `t_718652f`, flow session `sess_0c3b4739f627`.

## Residual risks / exclusions

- Google Search Console recrawl and validation remain asynchronous after deployment; this PR repairs the crawl signals but cannot guarantee Google's indexing decision.
- `www` TLS/ingress, robots asset policy, and the `/404/` defect are explicitly outside issue #139 and unchanged.
- A pre-existing live-content visual validation warning for `quantum-readiness-for-agent-workflows` is unrelated; no blog content changed here.
