### PR TITLE
fix(deploy): serialize RWO pod replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This site runs as a server-side rendered (SSR) Astro application:
 - **Runtime**: Node.js on port 80
 - **Deployment**: Kubernetes with Helm charts
 - **Storage**: PersistentVolume for blog content (externalized from container image)
-- **Updates**: Zero-downtime rolling deployments with health checks; main-branch CI tags the image with the exact `GITHUB_SHA`, passes that same value as `deploymentRevision`, uses the pod-template annotation to force replacement pods, and waits for rollout completion before live verification
+- **Updates**: Health-checked `Recreate` deployments serialize access to the single-node `ReadWriteOnce` posts volume; main-branch CI tags the image with the exact `GITHUB_SHA`, passes that same value as `deploymentRevision`, uses the pod-template annotation to force a replacement pod, and waits for rollout completion before live verification
 - **SSL**: Automatic TLS certificate provisioning via cert-manager
 - **Analytics**: GA4 browser measurement is conditional on `PUBLIC_GA_MEASUREMENT_ID`; the editorial pageview contract is summarized here and owned in [`docs/ga4-editorial-analytics-contract.md`](docs/ga4-editorial-analytics-contract.md)
 
@@ -59,7 +59,7 @@ This site runs as a server-side rendered (SSR) Astro application:
 /
 ├── helm/                    # Kubernetes Helm charts
 │   ├── templates/
-│   │   ├── deployment.yaml  # K8s deployment with rolling updates
+│   │   ├── deployment.yaml  # K8s deployment with RWO-safe replacement
 │   │   ├── service.yaml     # ClusterIP service
 │   │   ├── ingress.yaml     # NGINX ingress with TLS
 │   │   ├── pvc.yaml         # PersistentVolumeClaim for blog content
@@ -256,7 +256,7 @@ GitHub Actions workflow (`.github/workflows/deploy.yaml`):
 ## 🎨 Features
 
 - Server-side rendering for optimal SEO
-- Zero-downtime rolling deployments
+- RWO-safe, health-checked replacement deployments
 - Automatic TLS certificate management
 - Persistent blog content storage
 - Durable repo-backed blog visuals under `/assets/blog/<post-slug>/`

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -5,10 +5,9 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: RollingUpdate
-    rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 0
+    # A single ReadWriteOnce posts volume cannot safely support overlapping
+    # old/new pods when Kubernetes schedules them on different nodes.
+    type: Recreate
   selector:
     matchLabels:
       app: {{ .Values.service.name }}
@@ -19,16 +18,6 @@ spec:
       labels:
         app: {{ .Values.service.name }}
     spec:
-      # Force pods to schedule on same node to allow ReadWriteOnce PVC sharing during rolling update
-      affinity:
-        podAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
-                labelSelector:
-                  matchLabels:
-                    app: {{ .Values.service.name }}
-                topologyKey: kubernetes.io/hostname
       terminationGracePeriodSeconds: 30
       containers:
         - name: {{ .Values.service.name }}

--- a/tests/deploymentRolloutContract.test.mjs
+++ b/tests/deploymentRolloutContract.test.mjs
@@ -57,6 +57,15 @@ test("Helm defaults preserve local chart behavior when workflow overrides are ab
   assert.match(deploymentTemplate, /default \.Values\.image\.tag/);
 });
 
+test("single-replica ReadWriteOnce deployments replace pods without overlapping volume mounts", () => {
+  assert.match(values, /replicaCount:\s*1/);
+  assert.match(values, /accessMode:\s*ReadWriteOnce/);
+  assert.match(deploymentTemplate, /strategy:[\s\S]*type:\s*Recreate/);
+  assert.doesNotMatch(deploymentTemplate, /type:\s*RollingUpdate/);
+  assert.doesNotMatch(deploymentTemplate, /rollingUpdate:/);
+  assert.doesNotMatch(deploymentTemplate, /podAffinity:/);
+});
+
 test("deployment workflow fails closed on missing or mismatched revision inputs", () => {
   assert.match(workflow, /if \[ -z "\$\{IMAGE_TAG\}" \]; then[\s\S]*GITHUB_SHA is required for main deployments[\s\S]*exit 1/);
   assert.match(workflow, /if \[ -z "\$\{IMAGE_TAG\}" \]; then[\s\S]*build-push image-tag output is required for deployment[\s\S]*exit 1/);


### PR DESCRIPTION
## Summary

- switches the single-replica Kubernetes Deployment from `RollingUpdate` to `Recreate`
- removes pod-affinity guidance that could not guarantee safe cross-node access to the `ReadWriteOnce` posts volume
- documents the expected brief replacement outage and adds a regression test for the rollout/storage contract

## Controlling context

Follow-up to #139 and merged PR #148. PR #148 fixed the page-one indexing aliases, but its commit-bound deployment failed during Helm rollout: https://github.com/berryhill/bd-site/actions/runs/32609159686. Production then returned HTTP 503 across the crawl surface. This PR publishes the preserved attempt-3 recovery rather than reimplementing or altering the already-merged SEO fix.

Issue evidence: https://github.com/berryhill/bd-site/issues/139#issuecomment-5383505500

## Acceptance

- the single-replica `ReadWriteOnce` posts PVC is never mounted by overlapping old/new deployment pods
- Helm uses `Recreate` and contains no `RollingUpdate`, `rollingUpdate`, or pod-affinity overlap assumptions
- deployment documentation names the brief availability tradeoff
- the existing SHA-bound image, rollout wait, and post-deploy verification behavior remains unchanged
- after merge, the commit-bound deployment must succeed and production crawl routes must be read back before #139 is described as live

## Path boundary

`deployment-touching`

Changed surfaces:
- `helm/templates/deployment.yaml`
- `tests/deploymentRolloutContract.test.mjs`
- `README.md`

## Validation

- `pnpm test` — pass; includes the new RWO/Recreate rollout contract
- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run build` — pass
- staged diff reviewed: 3 intended files, 15 insertions, 17 deletions
- local and remote feature heads verified equal at `6e1dcedda14926abd77b32caaf34402ec1bec29f`

## Prior attempts and residual risk

- PR #148 is already merged; this is a separate deployment-recovery lineage.
- The failed deployment run is not treated as success of this PR.
- `Recreate` intentionally allows a brief outage while the old pod terminates and the replacement becomes ready. It prioritizes deterministic RWO volume custody over impossible zero-downtime overlap with the current one-replica/one-RWO-volume architecture.
- Live recovery, redirect/canonical behavior, sitemap/RSS/robots state, and stale-CDN behavior remain unverified until this exact head is merged and its deployment succeeds.

Refs #139
