### PR TITLE
fix(deploy): capture rollout failure diagnostics

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -87,7 +87,29 @@ jobs:
           fi
           echo "Deploying ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_ORG }}/${{ env.DOCKER_IMAGE }}:${IMAGE_TAG} with revision ${GITHUB_SHA}"
           helm upgrade --install bd-site ./helm -f ./helm/values.yaml --install --set dopplerToken="${{ env.DOPPLER_TOKEN }}" --set image.tag="${IMAGE_TAG}" --set deploymentRevision="${GITHUB_SHA}"
+          set +e
           kubectl rollout status deployment/bd-site --timeout=180s
+          ROLLOUT_STATUS=$?
+          set -e
+
+          if [ "${ROLLOUT_STATUS}" -ne 0 ]; then
+            echo "Deployment rollout failed with status ${ROLLOUT_STATUS}; collecting bounded diagnostics" >&2
+            NAMESPACE="$(kubectl get deployment bd-site -o jsonpath='{.metadata.namespace}' 2>/dev/null || true)"
+            NAMESPACE="${NAMESPACE:-default}"
+
+            kubectl get pods -n "${NAMESPACE}" -l app=bd-site -o wide || true
+            kubectl get pods -n "${NAMESPACE}" -l app=bd-site -o name 2>/dev/null |
+              while IFS= read -r POD_NAME; do
+                [ -n "${POD_NAME}" ] || continue
+                kubectl describe -n "${NAMESPACE}" "${POD_NAME}" || true
+                kubectl logs -n "${NAMESPACE}" "${POD_NAME}" --all-containers=true --tail=120 || true
+                kubectl logs -n "${NAMESPACE}" "${POD_NAME}" --all-containers=true --previous --tail=120 || true
+              done
+            kubectl get events -n "${NAMESPACE}" --field-selector involvedObject.kind=Pod --sort-by=.metadata.creationTimestamp |
+              tail -n 80 || true
+            exit "${ROLLOUT_STATUS}"
+          fi
+
           kubectl get pods -l app=bd-site -o wide
           curl -fsS https://berryhill.dev/posts/ >/dev/null || true
           kubectl logs deployment/bd-site --tail=120

--- a/tests/deploymentRolloutContract.test.mjs
+++ b/tests/deploymentRolloutContract.test.mjs
@@ -72,6 +72,30 @@ test("deployment workflow fails closed on missing or mismatched revision inputs"
   assert.match(workflow, /if \[ "\$\{IMAGE_TAG\}" != "\$\{GITHUB_SHA\}" \]; then[\s\S]*does not match GitHub revision[\s\S]*exit 1/);
 });
 
+test("rollout failures emit bounded pod diagnostics and preserve the rollout exit status", () => {
+  assert.match(
+    workflow,
+    /set \+e\s+kubectl rollout status deployment\/bd-site --timeout=180s\s+ROLLOUT_STATUS=\$\?\s+set -e/
+  );
+  assert.match(workflow, /if \[ "\$\{ROLLOUT_STATUS\}" -ne 0 \]; then/);
+  assert.match(workflow, /kubectl get pods -n "\$\{NAMESPACE\}" -l app=bd-site -o wide \|\| true/);
+  assert.match(workflow, /kubectl describe -n "\$\{NAMESPACE\}" "\$\{POD_NAME\}" \|\| true/);
+  assert.match(
+    workflow,
+    /kubectl logs -n "\$\{NAMESPACE\}" "\$\{POD_NAME\}" --all-containers=true --tail=120 \|\| true/
+  );
+  assert.match(
+    workflow,
+    /kubectl logs -n "\$\{NAMESPACE\}" "\$\{POD_NAME\}" --all-containers=true --previous --tail=120 \|\| true/
+  );
+  assert.match(
+    workflow,
+    /kubectl get events -n "\$\{NAMESPACE\}" --field-selector involvedObject\.kind=Pod --sort-by=\.metadata\.creationTimestamp \|\s+tail -n 80 \|\| true/
+  );
+  assert.match(workflow, /exit "\$\{ROLLOUT_STATUS\}"/);
+  assert.doesNotMatch(workflow, /kubectl logs[^\n]*--follow/);
+});
+
 console.log(`PASS ${passed} FAIL ${failed}`);
 
 if (failed > 0) {


### PR DESCRIPTION
## Summary

Supports #139 by making failed production rollouts diagnosable without weakening the deployment gate.

- captures the rollout exit status instead of losing the job immediately to fail-fast shell behavior
- on failure, prints bounded pod inventory, pod descriptions, current logs, previous-container logs, and recent pod events
- preserves the original nonzero rollout status after diagnostics
- keeps diagnostics bounded (`--tail=120`, final 80 events) and never follows logs

## Issue acceptance served

The original Search Console fix remains merged, but #139 must stay open until a commit-bound deployment is healthy and the live archive/crawl contract is verified. This follow-up addresses the recovery prerequisite: if the replacement pod is still unavailable, the workflow must expose enough bounded Kubernetes evidence to distinguish image pull, PVC mount, scheduling, secret injection, probe, crash-loop, and startup failures.

This PR does not claim the page-one redirects are live and does not restart Google Search Console validation.

## Prior attempts and current base

- PR #148 merged the archive page-one consolidation, but deployment run 32609159686 timed out and production remained unavailable.
- PR #151 merged the ReadWriteOnce/Recreate recovery, but deployment run 32613609376 timed out before its in-step diagnostic commands could run.
- This branch is based on `main` at `b86b6a65d9e7cdee126ae4d14817430053b66d1b`, preserving the subsequent GHCR recovery commits and their always-run summary diagnostic step.
- This change adds the missing failure-path detail and original-exit preservation; it does not revert or replace those recoveries.

## Changed surfaces

- `.github/workflows/deploy.yaml`
- `tests/deploymentRolloutContract.test.mjs`

Path boundary: deployment-touching.

## Validation

- `node tests/deploymentRolloutContract.test.mjs` — PASS 6 / FAIL 0
- `pnpm test` — PASS; three pre-existing legacy title-length advisories remain non-failing
- `pnpm run lint` — PASS
- `pnpm run format:check` — PASS
- `pnpm run build` — PASS; existing Astro prerender header warnings only
- `git diff --check` — PASS
- local head equals remote branch head: `ba5472cf60864dc6d0c2e78b7ec7791bad56a8db`

## Visual and crawl evidence

No visual, page markup, canonical, sitemap, feed, or crawl-source code changes in this PR. Browser screenshot evidence is not applicable to this deployment-workflow-only slice. The required live crawl readback remains a post-merge gate for #139, not evidence available from this local workflow change.

## Residual risk and rollback

- The next main-branch deployment can still fail; this PR makes that failure actionable while preserving fail-closed behavior.
- Kubernetes `describe` output can be verbose, but pod count is label-bounded and logs/events are explicitly bounded.
- Rollback: revert this commit to restore immediate fail-fast rollout behavior, at the cost of losing detailed failure evidence.
