### PR TITLE
fix: stabilize deployment and preserve rollback PVC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,14 @@ jobs:
       - name: "📦 Install dependencies"
         run: pnpm install
 
+      - name: "⚓ Install Helm"
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.9.4
+
+      - name: "🧪 Run tests"
+        run: pnpm test
+
       - name: "🔎 Lint code"
         run: pnpm run lint
 

--- a/README.md
+++ b/README.md
@@ -163,16 +163,41 @@ service:
   targetPort: 80
 ingress:
   host: berryhill.dev
-volumes:
-  postsContent:
-    enabled: true
-    pvcName: bd-site-posts-pvc
-    size: 25Gi
-    storageClassName: ""
-    accessMode: ReadWriteOnce
+contentStorage:
+  filesystem:
+    pvc:
+      create: true
+      mount: true
+      existingClaim: bd-site-posts-pvc
+      preserveOnDelete: true
+      size: 25Gi
+      storageClassName: ""
+      accessMode: ReadWriteOnce
 ```
 
 In CI, do not treat the static `image.tag` above as the deployment mechanism. The GitHub Actions workflow builds and pushes `ghcr.io/berryhill/bd-site-app:${GITHUB_SHA}`, then runs Helm with both `--set image.tag="${GITHUB_SHA}"` and `--set deploymentRevision="${GITHUB_SHA}"`. The chart writes `berryhill.dev/deployment-revision` onto the pod template, so a new commit changes the Deployment spec and forces Kubernetes to create replacement pods even when other values are unchanged.
+
+### Filesystem rollback claim
+
+The default filesystem mode creates and mounts the existing production claim name, `bd-site-posts-pvc`. `preserveOnDelete: true` adds Helm's `helm.sh/resource-policy: keep` annotation so uninstalling the release or later rendering the chart without the PVC does not delete the claim. This is the rollback source for a future object-storage cutover; do not migrate or delete its content as part of a deployment-mode change.
+
+PVC creation and pod mounting are independent:
+
+- Default filesystem mode: `create: true`, `mount: true`.
+- Preserved-but-unmounted preparation: keep `create: true` and set `mount: false`. The claim remains rendered and retained, while the Deployment contains neither a posts `volumeMount` nor a posts `volume`; no `emptyDir` replacement is created.
+- Operator-managed claim: set `create: false`, keep `mount: true`, and set `existingClaim` to the claim name. Helm does not create the PVC but the pod mounts that existing claim.
+
+The Helm keep annotation protects the claim from Helm deletion, but it does not change the backing PersistentVolume's reclaim policy. Before any storage migration, verify that the claim is bound and record the backing PV policy without reading cluster credentials or secret data:
+
+```bash
+NAMESPACE=default
+CLAIM=bd-site-posts-pvc
+PV_NAME="$(kubectl get pvc "${CLAIM}" -n "${NAMESPACE}" -o jsonpath='{.spec.volumeName}')"
+test -n "${PV_NAME}"
+kubectl get pv "${PV_NAME}" -o jsonpath='{.metadata.name}{"\t"}{.spec.persistentVolumeReclaimPolicy}{"\n"}'
+```
+
+The migration prerequisite is an explicit `Retain` policy for the backing PV. If readback reports another policy, stop before cutover and have the cluster operator change and re-verify it; this repository change does not mutate production storage.
 
 ## 🔐 Environment Variables
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -61,6 +61,34 @@ kubectl rollout status deployment/bd-site --timeout=180s
 
 For manual deployments, use the same immutable revision value for both `image.tag` and `deploymentRevision`. This mirrors the GitHub Actions main-branch contract, where the image tag is the exact `GITHUB_SHA` and the chart receives that same revision for the pod-template annotation.
 
+### Preserve the rollback PVC independently of mounting
+
+The chart defaults to the current filesystem-backed production behavior:
+
+```yaml
+contentStorage:
+  filesystem:
+    pvc:
+      create: true
+      mount: true
+      existingClaim: bd-site-posts-pvc
+      preserveOnDelete: true
+```
+
+`create` controls whether Helm renders the PVC. `mount` independently controls whether the Deployment renders `/app/src/data/blog` as a `volumeMount` and matching PVC volume. With `create: true` and `mount: false`, Helm preserves the claim as a rollback source but the application pod has no posts-content volume. The chart never substitutes `emptyDir` when mounting is disabled. Set `create: false` only when `existingClaim` is managed outside this release.
+
+`preserveOnDelete: true` applies `helm.sh/resource-policy: keep` to a chart-created PVC. That protects the claim from Helm deletion; the backing PV remains governed by its Kubernetes reclaim policy. Before any object-storage migration, use credential-safe metadata readback and require `Retain`:
+
+```bash
+NAMESPACE=default
+CLAIM=bd-site-posts-pvc
+PV_NAME="$(kubectl get pvc "${CLAIM}" -n "${NAMESPACE}" -o jsonpath='{.spec.volumeName}')"
+test -n "${PV_NAME}"
+kubectl get pv "${PV_NAME}" -o jsonpath='{.metadata.name}{"\t"}{.spec.persistentVolumeReclaimPolicy}{"\n"}'
+```
+
+If the policy is not `Retain`, stop before migration and route the policy change to the cluster operator. Do not print kubeconfig, Doppler values, or Kubernetes Secret content as verification.
+
 ### Method 2: Using Helm CLI Argument
 
 ```bash

--- a/helm/examples/deployment-recreate.yaml
+++ b/helm/examples/deployment-recreate.yaml
@@ -29,9 +29,11 @@ spec:
           env:
             - name: DOPPLER_TOKEN
               value: {{ .Values.dopplerToken }}
+          {{- if .Values.contentStorage.filesystem.pvc.mount }}
           volumeMounts:
             - name: posts-content
               mountPath: /app/src/data/blog
+          {{- end }}
           readinessProbe:
             httpGet:
               path: /
@@ -50,11 +52,9 @@ spec:
             timeoutSeconds: 3
             successThreshold: 1
             failureThreshold: 3
+      {{- if .Values.contentStorage.filesystem.pvc.mount }}
       volumes:
         - name: posts-content
-          {{- if .Values.volumes.postsContent.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.volumes.postsContent.pvcName }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
+            claimName: {{ .Values.contentStorage.filesystem.pvc.existingClaim }}
+      {{- end }}

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -32,9 +32,11 @@ spec:
           env:
             - name: DOPPLER_TOKEN
               value: {{ .Values.dopplerToken | quote }}
+          {{- if .Values.contentStorage.filesystem.pvc.mount }}
           volumeMounts:
             - name: posts-content
               mountPath: /app/src/data/blog
+          {{- end }}
           lifecycle:
             preStop:
               exec:
@@ -57,11 +59,9 @@ spec:
             timeoutSeconds: 3
             successThreshold: 1
             failureThreshold: 3
+      {{- if .Values.contentStorage.filesystem.pvc.mount }}
       volumes:
         - name: posts-content
-          {{- if .Values.volumes.postsContent.enabled }}
           persistentVolumeClaim:
-            claimName: {{ .Values.volumes.postsContent.pvcName }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
+            claimName: {{ .Values.contentStorage.filesystem.pvc.existingClaim }}
+      {{- end }}

--- a/helm/templates/pvc.yaml
+++ b/helm/templates/pvc.yaml
@@ -1,15 +1,20 @@
-{{- if .Values.volumes.postsContent.enabled }}
+{{- $pvc := .Values.contentStorage.filesystem.pvc -}}
+{{- if $pvc.create }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ .Values.volumes.postsContent.pvcName }}
+  name: {{ $pvc.existingClaim }}
+  {{- if $pvc.preserveOnDelete }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   accessModes:
-    - {{ .Values.volumes.postsContent.accessMode | default "ReadWriteMany" }}
+    - {{ $pvc.accessMode | default "ReadWriteOnce" }}
   resources:
     requests:
-      storage: {{ .Values.volumes.postsContent.size }}
-  {{- if .Values.volumes.postsContent.storageClassName }}
-  storageClassName: {{ .Values.volumes.postsContent.storageClassName }}
+      storage: {{ $pvc.size }}
+  {{- if $pvc.storageClassName }}
+  storageClassName: {{ $pvc.storageClassName }}
   {{- end }}
 {{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -29,10 +29,15 @@ ingress:
 
 dopplerToken: ""
 
-volumes:
-  postsContent:
-    enabled: true
-    pvcName: bd-site-posts-pvc
-    size: 25Gi
-    storageClassName: ""  # Use default storage class
-    accessMode: ReadWriteOnce  # Linode Block Storage only supports ReadWriteOnce
+contentStorage:
+  filesystem:
+    pvc:
+      # Creation and mounting are independent so object-mode preparation can
+      # retain the rollback claim without attaching it to the application pod.
+      create: true
+      mount: true
+      existingClaim: bd-site-posts-pvc
+      preserveOnDelete: true
+      size: 25Gi
+      storageClassName: ""  # Use default storage class
+      accessMode: ReadWriteOnce  # Linode Block Storage only supports ReadWriteOnce

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "ENV=workstation astro dev",
     "dev:prod": "doppler run -- astro dev",
     "build": "astro build",
-    "test": "node tests/blogVisualAssets.test.mjs && node tests/socialPreviewMeta.test.mjs && node tests/socialPreviewReadiness.test.mjs && node tests/dynamicPostOgImageEndpoint.test.mjs && node tests/dynamicPostOgImageRoute.test.mjs && node tests/ogBrandTemplates.test.mjs && node tests/structuredData.test.mjs && node tests/url.test.mjs && node tests/crawlSignals.test.mjs && node tests/googleSearchConsole.test.mjs && node tests/duckDuckGoCrawlSignal.test.mjs && node tests/yahooPostCrawlSignals.test.mjs && node tests/ga4EditorialMapping.test.mjs && node tests/postTitleQuality.test.mjs && node tests/seoCrawlSurface.test.mjs && node scripts/checkSeoCrawlSurface.mjs && node tests/publicPostFilter.test.mjs && node tests/homepagePositioning.test.mjs && node tests/homepagePosts.test.mjs && node tests/homepageFleet.test.mjs && node tests/aboutPositioning.test.mjs && node tests/postsLlmsPositioning.test.mjs && node tests/visualSystemPolish.test.mjs && node tests/terminalBrandSurfaces.test.mjs && node tests/deploymentRolloutContract.test.mjs",
+    "test": "tsx tests/blogVisualAssets.test.mjs && tsx tests/socialPreviewMeta.test.mjs && tsx tests/socialPreviewReadiness.test.mjs && tsx tests/dynamicPostOgImageEndpoint.test.mjs && tsx tests/dynamicPostOgImageRoute.test.mjs && tsx tests/ogBrandTemplates.test.mjs && tsx tests/structuredData.test.mjs && tsx tests/url.test.mjs && tsx tests/crawlSignals.test.mjs && tsx tests/googleSearchConsole.test.mjs && tsx tests/duckDuckGoCrawlSignal.test.mjs && tsx tests/yahooPostCrawlSignals.test.mjs && tsx tests/ga4EditorialMapping.test.mjs && tsx tests/postTitleQuality.test.mjs && tsx tests/seoCrawlSurface.test.mjs && tsx scripts/checkSeoCrawlSurface.mjs && tsx tests/publicPostFilter.test.mjs && tsx tests/homepagePositioning.test.mjs && tsx tests/homepagePosts.test.mjs && tsx tests/homepageFleet.test.mjs && tsx tests/aboutPositioning.test.mjs && tsx tests/postsLlmsPositioning.test.mjs && tsx tests/visualSystemPolish.test.mjs && tsx tests/terminalBrandSurfaces.test.mjs && tsx tests/deploymentRolloutContract.test.mjs",
     "check:social-preview": "node scripts/checkSocialPreview.mjs",
     "check:seo-crawl-surface": "node scripts/checkSeoCrawlSurface.mjs",
     "check:search-visibility": "node scripts/checkSearchVisibility.mjs",
@@ -49,6 +49,7 @@
     "prettier": "^3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "prettier-plugin-tailwindcss": "^0.6.13",
+    "tsx": "^4.23.12",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.36.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,10 @@ importers:
         version: 2.6.2
       '@tailwindcss/vite':
         specifier: ^4.1.11
-        version: 4.1.11(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0))
+        version: 4.1.11(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0))
       astro:
         specifier: ^5.12.0
-        version: 5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(typescript@5.8.3)(yaml@2.7.0)
+        version: 5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.7.0)
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
@@ -59,7 +59,7 @@ importers:
         version: 0.9.4(prettier-plugin-astro@0.14.1)(prettier@3.6.2)(typescript@5.8.3)
       '@astrojs/node':
         specifier: ^9.5.0
-        version: 9.5.0(astro@5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(typescript@5.8.3)(yaml@2.7.0))
+        version: 9.5.0(astro@5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.7.0))
       '@pagefind/default-ui':
         specifier: ^1.3.0
         version: 1.3.0
@@ -96,6 +96,9 @@ importers:
       prettier-plugin-tailwindcss:
         specifier: ^0.6.13
         version: 0.6.13(prettier-plugin-astro@0.14.1)(prettier@3.6.2)
+      tsx:
+        specifier: ^4.23.12
+        version: 4.23.12
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
@@ -214,8 +217,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.2':
+    resolution: {integrity: sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.0':
     resolution: {integrity: sha512-grvv8WncGjDSyUBjN9yHXNt+cq0snxXbDxy5pJtzMKGmmpPxeAmAhWxXI+01lU5rwZomDgD3kJwulEnhTRUd6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.2':
+    resolution: {integrity: sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -226,8 +241,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.2':
+    resolution: {integrity: sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.0':
     resolution: {integrity: sha512-m/ix7SfKG5buCnxasr52+LI78SQ+wgdENi9CqyCXwjVR2X4Jkz+BpC3le3AoBPYTC9NHklwngVXvbJ9/Akhrfg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.2':
+    resolution: {integrity: sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -238,8 +265,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.2':
+    resolution: {integrity: sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.0':
     resolution: {integrity: sha512-DgDaYsPWFTS4S3nWpFcMn/33ZZwAAeAFKNHNa1QN0rI4pUjgqf0f7ONmXf6d22tqTY+H9FNdgeaAa+YIFUn2Rg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.2':
+    resolution: {integrity: sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -250,8 +289,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    resolution: {integrity: sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.0':
     resolution: {integrity: sha512-mrSgt7lCh07FY+hDD1TxiTyIHyttn6vnjesnPoVDNmDfOmggTLXRv8Id5fNZey1gl/V2dyVK1VXXqVsQIiAk+A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.2':
+    resolution: {integrity: sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -262,8 +313,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.2':
+    resolution: {integrity: sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.0':
     resolution: {integrity: sha512-vkB3IYj2IDo3g9xX7HqhPYxVkNQe8qTK55fraQyTzTX/fxaDtXiEnavv9geOsonh2Fd2RMB+i5cbhu2zMNWJwg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.2':
+    resolution: {integrity: sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -274,8 +337,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.2':
+    resolution: {integrity: sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.0':
     resolution: {integrity: sha512-fC95c/xyNFueMhClxJmeRIj2yrSMdDfmqJnyOY4ZqsALkDrrKJfIg5NTMSzVBr5YW1jf+l7/cndBfP3MSDpoHw==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.2':
+    resolution: {integrity: sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -286,8 +361,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.2':
+    resolution: {integrity: sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.0':
     resolution: {integrity: sha512-NhyOejdhRGS8Iwv+KKR2zTq2PpysF9XqY+Zk77vQHqNbo/PwZCzB5/h7VGuREZm1fixhs4Q/qWRSi5zmAiO4Fw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.2':
+    resolution: {integrity: sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -298,8 +385,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.2':
+    resolution: {integrity: sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.0':
     resolution: {integrity: sha512-XM2BFsEBz0Fw37V0zU4CXfcfuACMrppsMFKdYY2WuTS3yi8O1nFOhil/xhKTmE1nPmVyvQJjJivgDT+xh8pXJA==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.2':
+    resolution: {integrity: sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -310,8 +409,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.2':
+    resolution: {integrity: sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.0':
     resolution: {integrity: sha512-RuG4PSMPFfrkH6UwCAqBzauBWTygTvb1nxWasEJooGSJ/NwRw7b2HOwyRTQIU97Hq37l3npXoZGYMy3b3xYvPw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -322,8 +433,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.2':
+    resolution: {integrity: sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.0':
     resolution: {integrity: sha512-21sUNbq2r84YE+SJDfaQRvdgznTD8Xc0oc3p3iW/a1EVWeNj/SdUCbm5U0itZPQYRuRTW20fPMWMpcrciH2EJw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.2':
+    resolution: {integrity: sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -334,8 +457,26 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.2':
+    resolution: {integrity: sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    resolution: {integrity: sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/sunos-x64@0.25.0':
     resolution: {integrity: sha512-bxI7ThgLzPrPz484/S9jLlvUAHYMzy6I0XiU1ZMeAEOBcS0VePBFxh1JjTQt3Xiat5b6Oh4x7UC7IwKQKIJRIg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.2':
+    resolution: {integrity: sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
@@ -346,14 +487,32 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-arm64@0.28.2':
+    resolution: {integrity: sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.0':
     resolution: {integrity: sha512-eSNxISBu8XweVEWG31/JzjkIGbGIJN/TrRoiSVZwZ6pkC6VX4Im/WV2cz559/TXLcYbcrDN8JtKgd9DJVIo8GA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.2':
+    resolution: {integrity: sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.0':
     resolution: {integrity: sha512-ZENoHJBxA20C2zFzh6AI4fT6RraMzjYw4xKWemRTRmRVtN9c5DcH9r/f2ihEkMjOW5eGgrwCslG/+Y/3bL+DHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.2':
+    resolution: {integrity: sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1565,6 +1724,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.28.2:
+    resolution: {integrity: sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -1615,6 +1779,7 @@ packages:
   eslint@9.30.1:
     resolution: {integrity: sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2802,6 +2967,7 @@ packages:
   tsconfck@3.1.5:
     resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0
@@ -2811,6 +2977,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.12:
+    resolution: {integrity: sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -3302,10 +3473,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/node@9.5.0(astro@5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(typescript@5.8.3)(yaml@2.7.0))':
+  '@astrojs/node@9.5.0(astro@5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.7.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.7.4
-      astro: 5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(typescript@5.8.3)(yaml@2.7.0)
+      astro: 5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.7.0)
       send: 1.2.0
       server-destroy: 1.0.1
     transitivePeerDependencies:
@@ -3394,76 +3565,154 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.0':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.2':
+    optional: true
+
   '@esbuild/android-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.2':
     optional: true
 
   '@esbuild/android-arm@0.25.0':
     optional: true
 
+  '@esbuild/android-arm@0.28.2':
+    optional: true
+
   '@esbuild/android-x64@0.25.0':
+    optional: true
+
+  '@esbuild/android-x64@0.28.2':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.0':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.2':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.2':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.0':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.2':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.2':
     optional: true
 
   '@esbuild/linux-arm64@0.25.0':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.2':
+    optional: true
+
   '@esbuild/linux-arm@0.25.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.2':
     optional: true
 
   '@esbuild/linux-ia32@0.25.0':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.2':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.2':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.0':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.2':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.2':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.0':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.2':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.2':
     optional: true
 
   '@esbuild/linux-x64@0.25.0':
     optional: true
 
+  '@esbuild/linux-x64@0.28.2':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.0':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.2':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.2':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.0':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.2':
+    optional: true
+
   '@esbuild/sunos-x64@0.25.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.2':
     optional: true
 
   '@esbuild/win32-arm64@0.25.0':
     optional: true
 
+  '@esbuild/win32-arm64@0.28.2':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.0':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.2':
+    optional: true
+
   '@esbuild/win32-x64@0.25.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.2':
     optional: true
 
   '@eslint-community/eslint-utils@4.4.1(eslint@9.30.1(jiti@2.4.2))':
@@ -3992,12 +4241,12 @@ snapshots:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.1.11
 
-  '@tailwindcss/vite@4.1.11(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0))':
+  '@tailwindcss/vite@4.1.11(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0))':
     dependencies:
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0)
+      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0)
 
   '@types/debug@4.1.12':
     dependencies:
@@ -4271,7 +4520,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  astro@5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(typescript@5.8.3)(yaml@2.7.0):
+  astro@5.12.0(jiti@2.4.2)(lightningcss@1.30.1)(rollup@4.41.1)(tsx@4.23.12)(typescript@5.8.3)(yaml@2.7.0):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.6.1
@@ -4327,8 +4576,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.15.0
       vfile: 6.0.3
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0)
-      vitefu: 1.0.6(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0))
+      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0)
+      vitefu: 1.0.6(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.1
@@ -4618,6 +4867,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.0
       '@esbuild/win32-ia32': 0.25.0
       '@esbuild/win32-x64': 0.25.0
+
+  esbuild@0.28.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.2
+      '@esbuild/android-arm': 0.28.2
+      '@esbuild/android-arm64': 0.28.2
+      '@esbuild/android-x64': 0.28.2
+      '@esbuild/darwin-arm64': 0.28.2
+      '@esbuild/darwin-x64': 0.28.2
+      '@esbuild/freebsd-arm64': 0.28.2
+      '@esbuild/freebsd-x64': 0.28.2
+      '@esbuild/linux-arm': 0.28.2
+      '@esbuild/linux-arm64': 0.28.2
+      '@esbuild/linux-ia32': 0.28.2
+      '@esbuild/linux-loong64': 0.28.2
+      '@esbuild/linux-mips64el': 0.28.2
+      '@esbuild/linux-ppc64': 0.28.2
+      '@esbuild/linux-riscv64': 0.28.2
+      '@esbuild/linux-s390x': 0.28.2
+      '@esbuild/linux-x64': 0.28.2
+      '@esbuild/netbsd-arm64': 0.28.2
+      '@esbuild/netbsd-x64': 0.28.2
+      '@esbuild/openbsd-arm64': 0.28.2
+      '@esbuild/openbsd-x64': 0.28.2
+      '@esbuild/openharmony-arm64': 0.28.2
+      '@esbuild/sunos-x64': 0.28.2
+      '@esbuild/win32-arm64': 0.28.2
+      '@esbuild/win32-ia32': 0.28.2
+      '@esbuild/win32-x64': 0.28.2
 
   escalade@3.2.0: {}
 
@@ -6092,6 +6370,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.12:
+    dependencies:
+      esbuild: 0.28.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -6221,7 +6505,7 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0):
+  vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.5(picomatch@4.0.2)
@@ -6233,11 +6517,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1
+      tsx: 4.23.12
       yaml: 2.7.0
 
-  vitefu@1.0.6(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0)):
+  vitefu@1.0.6(vite@6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0)):
     optionalDependencies:
-      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.7.0)
+      vite: 6.3.5(jiti@2.4.2)(lightningcss@1.30.1)(tsx@4.23.12)(yaml@2.7.0)
 
   volar-service-css@0.0.62(@volar/language-service@2.4.11):
     dependencies:

--- a/tests/deploymentRolloutContract.test.mjs
+++ b/tests/deploymentRolloutContract.test.mjs
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 
 let passed = 0;
 let failed = 0;
@@ -24,14 +26,94 @@ function readRepoFile(path) {
   return readFileSync(new URL(`../${path}`, import.meta.url), "utf8");
 }
 
+function renderChart(setValues = []) {
+  const args = ["template", "bd-site", "./helm", "-f", "./helm/values.yaml"];
+  for (const value of setValues) {
+    args.push("--set", value);
+  }
+  return execFileSync("helm", args, {
+    cwd: fileURLToPath(new URL("../", import.meta.url)),
+    encoding: "utf8",
+  });
+}
+
+function renderedDocument(renderedChart, kind) {
+  return renderedChart
+    .split(/^---\s*$/m)
+    .find(document => new RegExp(`^kind: ${kind}$`, "m").test(document));
+}
+
 const workflow = readRepoFile(".github/workflows/deploy.yaml");
+const ciWorkflow = readRepoFile(".github/workflows/ci.yml");
 const values = readRepoFile("helm/values.yaml");
+const pvcTemplate = readRepoFile("helm/templates/pvc.yaml");
 const deploymentTemplate = readRepoFile("helm/templates/deployment.yaml");
 const serviceAccountPath = new URL("../helm/templates/serviceaccount.yaml", import.meta.url);
 const serviceAccountTemplate = existsSync(serviceAccountPath) ? readFileSync(serviceAccountPath, "utf8") : "";
 
 test("production deployments are serialized without cancelling an in-flight release", () => {
   assert.match(workflow, /concurrency:\s+group:\s*bd-site-production\s+cancel-in-progress:\s*false/);
+});
+
+test("pull request CI runs the repository tests before linting and building", () => {
+  const helmSetupIndex = ciWorkflow.indexOf("uses: azure/setup-helm@v4");
+  const testIndex = ciWorkflow.indexOf("run: pnpm test");
+  const lintIndex = ciWorkflow.indexOf("run: pnpm run lint");
+  const buildIndex = ciWorkflow.indexOf("run: pnpm run build");
+
+  assert.ok(helmSetupIndex >= 0, "PR CI must install Helm for chart render tests");
+  assert.ok(testIndex > helmSetupIndex, "PR CI must install Helm before running tests");
+  assert.ok(testIndex >= 0, "PR CI must run pnpm test");
+  assert.ok(lintIndex > testIndex, "PR CI must run tests before linting");
+  assert.ok(buildIndex > testIndex, "PR CI must run tests before building");
+});
+
+test("filesystem defaults render the retained PVC and mount it at the live posts path", () => {
+  assert.match(values, /contentStorage:[\s\S]*filesystem:[\s\S]*pvc:[\s\S]*create:\s*true/);
+  assert.match(values, /pvc:[\s\S]*mount:\s*true/);
+  assert.match(values, /existingClaim:\s*bd-site-posts-pvc/);
+  assert.match(values, /preserveOnDelete:\s*true/);
+  assert.match(pvcTemplate, /helm\.sh\/resource-policy/);
+
+  const rendered = renderChart();
+  const pvc = renderedDocument(rendered, "PersistentVolumeClaim");
+  const deployment = renderedDocument(rendered, "Deployment");
+
+  assert.ok(pvc, "default render must create the posts PVC");
+  assert.ok(deployment, "default render must include the deployment");
+  assert.match(pvc, /name: bd-site-posts-pvc/);
+  assert.match(pvc, /helm\.sh\/resource-policy: keep/);
+  assert.match(deployment, /name: posts-content[\s\S]*mountPath: \/app\/src\/data\/blog/);
+  assert.match(deployment, /persistentVolumeClaim:[\s\S]*claimName: bd-site-posts-pvc/);
+  assert.doesNotMatch(deployment, /emptyDir:/);
+});
+
+test("preserved-but-unmounted mode retains the PVC without any content volume", () => {
+  const rendered = renderChart(["contentStorage.filesystem.pvc.mount=false"]);
+  const pvc = renderedDocument(rendered, "PersistentVolumeClaim");
+  const deployment = renderedDocument(rendered, "Deployment");
+
+  assert.ok(pvc, "preserved mode must continue rendering the posts PVC");
+  assert.ok(deployment, "preserved mode must include the deployment");
+  assert.match(pvc, /name: bd-site-posts-pvc/);
+  assert.match(pvc, /helm\.sh\/resource-policy: keep/);
+  assert.doesNotMatch(deployment, /posts-content/);
+  assert.doesNotMatch(deployment, /\/app\/src\/data\/blog/);
+  assert.doesNotMatch(deployment, /emptyDir:/);
+});
+
+test("an externally managed existing claim can be mounted without rendering a PVC", () => {
+  const rendered = renderChart([
+    "contentStorage.filesystem.pvc.create=false",
+    "contentStorage.filesystem.pvc.existingClaim=operator-managed-posts",
+  ]);
+  const pvc = renderedDocument(rendered, "PersistentVolumeClaim");
+  const deployment = renderedDocument(rendered, "Deployment");
+
+  assert.equal(pvc, undefined);
+  assert.ok(deployment, "external-claim mode must include the deployment");
+  assert.match(deployment, /persistentVolumeClaim:[\s\S]*claimName: operator-managed-posts/);
+  assert.match(deployment, /mountPath: \/app\/src\/data\/blog/);
 });
 
 test("main deployment builds and pushes a SHA tag while exporting its immutable digest", () => {


### PR DESCRIPTION
## Summary

- decouples rollback-PVC creation and retention from application pod mounting
- removes the ephemeral `emptyDir` fallback when filesystem content mounting is disabled
- supports chart-created, preserved-but-unmounted, and externally managed existing-claim modes
- installs Helm and runs the repository test suite in pull-request CI
- makes the test suite load repository TypeScript imports through `tsx` on the documented Node 20 baseline
- documents the `bd-site-posts-pvc` retention contract and the required backing-PV `Retain` readback

Closes #156

## Acceptance evidence

- Main deployment immutable-image selection and failed-smoke behavior were already implemented in `.github/workflows/deploy.yaml` and remain covered by deployment contract tests.
- Default chart rendering creates and mounts `bd-site-posts-pvc` at `/app/src/data/blog` with `replicaCount: 1` and `Recreate` preserved.
- `contentStorage.filesystem.pvc.mount=false` keeps the retained PVC rendered while omitting both the posts `volumeMount` and posts volume; no `emptyDir` is emitted.
- `contentStorage.filesystem.pvc.create=false` with an explicit `existingClaim` mounts the operator-managed claim without rendering a PVC.
- The complete repository suite passes with Node v20.20.1, pnpm 10.11.1, and Helm v3.9.4 after replacing direct Node execution with the repository-owned `tsx` loader.
- No production content, credentials, routes, API behavior, or storage bytes were mutated.

## Changed surfaces

- `.github/workflows/ci.yml`
- `README.md`
- `helm/README.md`
- `helm/examples/deployment-recreate.yaml`
- `helm/templates/deployment.yaml`
- `helm/templates/pvc.yaml`
- `helm/values.yaml`
- `package.json`
- `pnpm-lock.yaml`
- `tests/deploymentRolloutContract.test.mjs`

Path boundary: deployment-touching.

## Validation

Executed in `node:20.20.1-bookworm` with pnpm 10.11.1 and the checksum-verified official Helm v3.9.4 Linux amd64 binary:

- `pnpm test` — passed, including deployment contract `PASS 17 FAIL 0`; three pre-existing non-failing legacy title advisories remain
- `pnpm run lint` — passed
- `pnpm run format:check` — passed
- `pnpm run build` — passed
- `git diff --check` — passed

The deployment contract test renders and verifies all three deterministic Helm modes:

- default filesystem-backed claim creation and mount
- retained PVC with content mounting disabled
- externally managed existing claim without chart PVC creation

## Prior attempts and residual risk

The previous exact PR head, `e2903c8e63d8b49b27d05afdf219c70afb47d4fe`, failed CI under Node 20 before deployment assertions ran because direct `node` execution could not load imported `.ts` files. Commit `f2f065c` adds `tsx` as a development dependency and routes the existing complete test sequence through it; no test was removed, skipped, weakened, or reordered.

Earlier local attempts also correctly deferred publication until Helm-backed render evidence existed. This head retains the three deterministic render modes and the original eight deployment-focused files.

The Helm keep annotation does not itself change the backing PersistentVolume reclaim policy. Before object-storage cutover, the cluster operator must read back the bound PV and verify `Retain` without exposing cluster credentials. After merge, Issue #156 still requires exact main deployment readback: selected immutable image, rollout completion, PVC preservation behavior, public HTTP smoke, and production commit binding.