### PR TITLE
Fix deployed blog visual asset validation

### DIFF
--- a/src/utils/blogVisualAssets.ts
+++ b/src/utils/blogVisualAssets.ts
@@ -41,6 +41,34 @@ function hasUnsafePathSegment(src: string): boolean {
   return src.split(/[\\/]/).some(segment => segment === "..");
 }
 
+function candidatePublicRoots(publicDir: string): string[] {
+  const sourcePublicRoot = path.resolve(publicDir);
+  const deployedStaticRoot = path.resolve(
+    sourcePublicRoot,
+    "..",
+    "dist",
+    "client"
+  );
+
+  return [...new Set([sourcePublicRoot, deployedStaticRoot])];
+}
+
+function resolveVisualAssetPath(src: string, publicDir: string): string | null {
+  for (const publicRoot of candidatePublicRoots(publicDir)) {
+    const assetPath = path.resolve(publicRoot, `.${src}`);
+
+    if (!assetPath.startsWith(`${publicRoot}${path.sep}`)) {
+      continue;
+    }
+
+    if (fs.existsSync(assetPath) && fs.statSync(assetPath).isFile()) {
+      return assetPath;
+    }
+  }
+
+  return null;
+}
+
 export function extractBlogImageReferences(
   markdown: string
 ): BlogImageReference[] {
@@ -137,8 +165,8 @@ export function validateBlogVisualAssets(
       });
     }
 
-    const assetPath = path.resolve(publicDir, `.${src}`);
     const publicRoot = path.resolve(publicDir);
+    const assetPath = path.resolve(publicRoot, `.${src}`);
 
     if (!assetPath.startsWith(`${publicRoot}${path.sep}`)) {
       issues.push({
@@ -148,7 +176,7 @@ export function validateBlogVisualAssets(
       continue;
     }
 
-    if (!fs.existsSync(assetPath) || !fs.statSync(assetPath).isFile()) {
+    if (!resolveVisualAssetPath(src, publicDir)) {
       issues.push({
         src,
         reason: `Referenced blog visual asset does not exist at ${path.relative(process.cwd(), assetPath)}.`,

--- a/tests/blogPostsApiRoute.test.mjs
+++ b/tests/blogPostsApiRoute.test.mjs
@@ -40,6 +40,15 @@ async function waitForServer(origin, child, output) {
 const port = await getFreePort();
 const origin = `http://127.0.0.1:${port}`;
 const storePath = await fs.mkdtemp(path.join(os.tmpdir(), "bd-posts-api-"));
+const runtimeVisualSlug = "draft-runtime-visual-fixture";
+const runtimeVisualAssetDir = path.join(
+  process.cwd(),
+  "dist",
+  "client",
+  "assets",
+  "blog",
+  runtimeVisualSlug
+);
 const apiKey = randomUUID();
 const output = [];
 const child = spawn(
@@ -70,7 +79,27 @@ const request = (method, body) =>
   });
 
 try {
+  await fs.mkdir(runtimeVisualAssetDir, { recursive: true });
+  await fs.writeFile(
+    path.join(runtimeVisualAssetDir, "pipeline.svg"),
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>'
+  );
   await waitForServer(origin, child, output);
+
+  const createRuntimeVisualDraft = await request("POST", {
+    title: "Draft Runtime Visual Fixture",
+    description: "Draft fixture with a built static visual reference",
+    content:
+      '![Pipeline diagram](/assets/blog/draft-runtime-visual-fixture/pipeline.svg "Build gate diagram")',
+    draft: true,
+    operationId: "create-draft-runtime-visual-fixture",
+  });
+  const createRuntimeVisualDraftText = await createRuntimeVisualDraft.text();
+  assert.equal(
+    createRuntimeVisualDraft.status,
+    201,
+    createRuntimeVisualDraftText
+  );
 
   const create = await request("POST", {
     title: "PATCH Retry Route Fixture",
@@ -101,8 +130,9 @@ try {
   const retryBody = JSON.parse(retryText);
   assert.deepEqual(retryBody, firstBody);
 
-  console.log("PASS 1 FAIL 0");
+  console.log("PASS 2 FAIL 0");
 } finally {
   child.kill("SIGTERM");
   await fs.rm(storePath, { recursive: true, force: true });
+  await fs.rm(runtimeVisualAssetDir, { recursive: true, force: true });
 }

--- a/tests/blogVisualAssets.test.mjs
+++ b/tests/blogVisualAssets.test.mjs
@@ -22,6 +22,28 @@ function createPublicDirWithAsset(postSlug = "durable-post") {
   return publicDir;
 }
 
+function createRuntimeRootWithBuiltAsset(postSlug = "durable-post") {
+  const appRoot = fs.mkdtempSync(path.join(os.tmpdir(), "bd-blog-runtime-"));
+  const publicDir = path.join(appRoot, "public");
+  const assetDir = path.join(
+    appRoot,
+    "dist",
+    "client",
+    "assets",
+    "blog",
+    postSlug
+  );
+
+  fs.mkdirSync(publicDir, { recursive: true });
+  fs.mkdirSync(assetDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(assetDir, "pipeline.svg"),
+    '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"></svg>'
+  );
+
+  return { appRoot, publicDir };
+}
+
 let passed = 0;
 let failed = 0;
 
@@ -81,6 +103,20 @@ test("accepts durable blog visual assets stored under public/assets/blog/<post-s
   );
 });
 
+test("accepts durable blog visual assets from the deployed dist/client static root", () => {
+  const { publicDir } = createRuntimeRootWithBuiltAsset();
+  const markdown =
+    '![Pipeline diagram](/assets/blog/durable-post/pipeline.svg "Build gate diagram")';
+
+  const result = validateBlogVisualAssets(markdown, {
+    postSlug: "durable-post",
+    publicDir,
+  });
+
+  assert.equal(result.valid, true);
+  assert.deepEqual(result.issues, []);
+});
+
 test("ignores external image URLs so existing posts remain unaffected", () => {
   const result = validateBlogVisualAssets(
     "![Remote source](https://images.example.test/photo.jpg)",
@@ -92,6 +128,21 @@ test("ignores external image URLs so existing posts remain unaffected", () => {
 
   assert.equal(result.valid, true);
   assert.deepEqual(result.issues, []);
+});
+
+test("does not use a remote-existence bypass for local blog asset references", () => {
+  const { publicDir } = createRuntimeRootWithBuiltAsset();
+  const result = validateBlogVisualAssets(
+    '![Missing local diagram](/assets/blog/durable-post/missing.svg "Missing local caption")',
+    {
+      postSlug: "durable-post",
+      publicDir,
+    }
+  );
+
+  assert.equal(result.valid, false);
+  assert.equal(result.issues.length, 1);
+  assert.match(result.issues[0].reason, /does not exist/);
 });
 
 test("rejects inline data image URIs", () => {


### PR DESCRIPTION
## Source issue

- Follow-up to https://github.com/berryhill/bd-site/issues/168
- Closes #168

## Classification

- Path boundary: app/source-code-touching with runtime/container acceptance
- Primary: backend
- Secondary: platform/runtime layout
- Brand risk: low copy risk; high publishing-pipeline integrity risk because weakening validation would damage visual provenance while the current false negative blocks reviewed operator-artifact diagrams.

## Prior PR audit and decision

- No open or closed PR exists for this head branch.
- PR #170 is the clean, merged asset-deployment PR linked to issue #168. It successfully deployed the reviewed SVGs, but production API validation exposed a separate runtime-layout false negative.
- This is a clean follow-up PR from current `main`; it does not reopen or modify PR #170.

## Summary

- Resolve durable local blog visuals against both the source checkout `public/` root and Astro’s deployed `dist/client/` static root.
- Preserve strict post-slug ownership, traversal protection, alt/caption requirements, and fail-closed local file existence checks.
- Add deterministic utility coverage for source and deployed layouts, missing files, and absence of any remote-existence bypass.
- Add API-route acceptance proving an authenticated draft payload can reference a visual present only in the built runtime static tree.

## Documentation reconciliation

- Audited the affected runtime-validation contract against repository docs.
- No documentation owns this internal root-resolution detail, so no docs were created, modified, or deleted.
- Existing public guidance remains accurate: durable visuals use `/assets/blog/<post-slug>/...` with alt text and a caption/title.

## Destructive-diff guard

```text
M  src/utils/blogVisualAssets.ts
M  tests/blogPostsApiRoute.test.mjs
M  tests/blogVisualAssets.test.mjs

3 files changed, 112 insertions(+), 3 deletions(-)
0 deleted files
```

## Validation

- `pnpm test` — pass (including runtime-layout utility and authenticated API acceptance)
- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run build` — pass

## Scope boundary

**app/source-code-touching**

No content, blog assets, deployment configuration, workflows, secrets, or production values are changed.