### PR TITLE
Lead the homepage with accountable business outcomes

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -2,13 +2,26 @@ export const SITE = {
   website: "https://berryhill.dev/", // replace this with your deployed domain
   author: "Berryhill",
   profile: "https://berryhill.dev/",
+  organization: {
+    name: "Berryhill Dev",
+    url: "https://berryhill.dev/",
+  },
+  operator: {
+    name: "Matt Berryhill",
+    url: "https://berryhill.dev/about/",
+  },
+  homepage: {
+    description:
+      "Berryhill Dev builds and operates bounded AI systems for measurable business outcomes, with explicit evidence boundaries and human accountability.",
+  },
   desc: "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.",
   title: "berryhill.dev",
   ogImage: "",
   socialPreview: {
-    title: "Field notes from an AI systems operator",
-    imageAlt: "Berryhill.dev — field notes from an AI systems operator",
-    imageVersion: "2",
+    title: "Measurable business outcomes through accountable AI systems",
+    imageAlt:
+      "Berryhill Dev — measurable business outcomes through accountable AI systems",
+    imageVersion: "3",
   },
   lightAndDarkMode: false,
   postPerIndex: 6,

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -13,10 +13,6 @@ import {
   getReadMinutes,
   selectHomepagePosts,
 } from "@/utils/homepagePosts";
-import {
-  curatedHomepageFleet,
-  getHomepageFleetCountLabel,
-} from "@/utils/homepageFleet";
 
 const posts = await getLiveBlogPosts();
 const sortedPosts = getSortedPosts(posts || []);
@@ -27,23 +23,29 @@ const formatDate = formatHomepageDate;
 const jsonLd = buildWebSiteJsonLd({
   name: SITE.title,
   url: SITE.website,
-  description: SITE.desc,
+  description: SITE.homepage.description,
   image: new URL(
     SITE.ogImage
       ? `/${SITE.ogImage}`
       : `/og.png?v=${SITE.socialPreview.imageVersion}`,
     SITE.website
   ).href,
-  author: SITE.author,
-  authorUrl: SITE.profile,
+  publisher: SITE.organization.name,
+  publisherUrl: SITE.organization.url,
+  creator: SITE.operator.name,
+  creatorUrl: SITE.operator.url,
 });
 ---
 
-<Layout jsonLd={jsonLd}>
-  <div class="window proto-window">
+<Layout
+  description={SITE.homepage.description}
+  socialDescription={SITE.homepage.description}
+  jsonLd={jsonLd}
+>
+  <div class="window proto-window outcome-home">
     <div class="titlebar">
       <button class="hamb" aria-label="Menu" type="button">&#9776;</button>
-      <span class="path">m@berryhill: ~/<b>berryhill.dev</b></span>
+      <span class="path">berryhill-dev: ~/<b>outcomes</b></span>
       <span class="gnome-ctrls"
         ><button class="gctl min" aria-label="Minimize" type="button"
           >&minus;</button
@@ -55,100 +57,250 @@ const jsonLd = buildWebSiteJsonLd({
       >
     </div>
     <div class="tabstrip">
-      <a class="tab on" href="/">~ home</a><a class="tab" href="/posts/"
-        >posts/</a
-      ><a class="tab" href="/about/">about.md</a><span
-        class="tabnew"
-        aria-hidden="true">+</span
-      >
+      <a class="tab on" href="/">~ outcomes</a><a class="tab" href="#proof"
+        >proof/</a
+      ><a class="tab" href="/posts/">writing/</a><a class="tab" href="/about/"
+        >about.md</a
+      ><span class="tabnew" aria-hidden="true">+</span>
     </div>
-    <div class="term">
-      <div class="line">
-        <span class="ps1"
-          >guest@berryhill <span class="sep">:</span>
-          <span class="cwd">~</span> $</span
-        ><span class="cmd">whoami --verbose</span>
-      </div>
-      <div class="who">
-        <div>
-          <h1>
-            matt<b>@berryhill</b><span
-              class="terminal-cursor"
-              aria-hidden="true"></span>
-          </h1><p>
-            <b>builder · operator · agent conductor.</b> I run a fleet of specialized
-            AI agents that design, research, code, review, write, analyze markets,
-            and ship software with me. This site is the public terminal into that
-            operating system.
+
+    <main class="term">
+      <section
+        class="outcome-hero"
+        id="outcomes"
+        aria-labelledby="outcome-title"
+      >
+        <p class="eyebrow">BERRYHILL DEV / AI-NATIVE OPERATING ORGANIZATION</p>
+        <h1 id="outcome-title">
+          Measurable business outcomes, delivered through accountable AI
+          systems.<span class="terminal-cursor" aria-hidden="true"></span>
+        </h1>
+        <p class="hero-deck">
+          Berryhill Dev builds and operates bounded AI systems designed to help
+          increase revenue, reduce costs, improve conversion and retention,
+          expand operational capacity, accelerate response, prevent expensive
+          failures, and improve margins.
+        </p>
+        <p class="hero-boundary">
+          Every system has a named business result, an evidence boundary, and a
+          human accountable for consequential decisions.
+        </p>
+        <div class="cta-row">
+          <a class="cta primary" href="/about/#connect"
+            >Tell us what needs to improve</a
+          >
+          <a class="cta secondary" href="#proof">See how outcomes are proven</a>
+        </div>
+      </section>
+
+      <section class="outcome-section" id="economic-problem">
+        <div class="section-label">01 · THE ECONOMIC PROBLEM</div>
+        <h2>
+          Recurring operating friction quietly compounds into economic loss.
+        </h2>
+        <p class="section-intro">
+          Berryhill Dev starts where an important result repeatedly crosses
+          people, tools, and decisions—and the current process cannot reliably
+          show where value is gained or lost.
+        </p>
+        <div class="outcome-grid cols-3">
+          <article>
+            <h3>A / Revenue leaks</h3><p>
+              Slow response, weak follow-up, and inconsistent handoffs reduce
+              conversion and retention.
+            </p>
+          </article>
+          <article>
+            <h3>B / Capacity stalls</h3><p>
+              Manual coordination and rework consume attention that should move
+              the business forward.
+            </p>
+          </article>
+          <article>
+            <h3>C / Failures compound</h3><p>
+              Missing controls and unclear ownership turn preventable errors
+              into margin, trust, and time losses.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="outcome-section" id="proof">
+        <div class="section-label">02 · PROOF / BOUNDARIES</div>
+        <h2>
+          An outcome is proven against a named baseline—not implied by polished
+          automation.
+        </h2>
+        <p class="section-intro">
+          Before work begins, Berryhill Dev names the result, baseline or proxy,
+          evaluation window, allowed actions, prohibited actions, dependencies,
+          and the evidence required for a go, revise, or stop decision.
+        </p>
+        <div class="proof-contract">
+          <p>
+            <b>EVALUATION CONTRACT · NOT CLIENT PROOF</b><span
+              >NO INVENTED METRICS</span
+            >
           </p>
-        </div><div class="status">
-          <div class="row-s">
-            <span><span class="dot"></span>status</span><b class="ok">online</b>
-          </div><div class="row-s"><span>agents</span><b>active</b></div><div
-            class="row-s"
-          >
-            <span>mode</span><b>human-led</b>
-          </div><div class="row-s"><span>shell</span><b>hermes</b></div><div
-            class="row-s"
-          >
-            <span>focus</span><b>systems</b>
-          </div><div class="row-s"><span>operator</span><b>matt</b></div>
+          <p class="proof-statement">
+            Evidence remains attached to the claim it supports.
+          </p>
+          <dl>
+            <div><dt>Result</dt><dd>Named and economically meaningful</dd></div>
+            <div><dt>Boundary</dt><dd>Allowed and prohibited actions</dd></div>
+            <div><dt>Evidence</dt><dd>Source, version, and limitation</dd></div>
+            <div><dt>Decision</dt><dd>Go, revise, or stop</dd></div>
+          </dl>
         </div>
-      </div>
-      <form class="cmdbar" onsubmit="event.preventDefault();">
-        <span class="ps">~/ $</span><input
-          type="text"
-          placeholder="try: fleet · posts · about · contact · curl GET /fleet"
-          autocomplete="off"
-        /><span class="hint">⌘K · ↵ to run</span>
-      </form>
-      <div class="line">
-        <span class="ps1"
-          >guest@berryhill <span class="sep">:</span>
-          <span class="cwd">~</span> $</span
-        ><span class="cmd">curl GET /fleet</span>
-      </div>
-      <p class="out" style="padding: 8px 0 6px;">
-        <b>200 OK</b> · application/json · <span class="k"
-          >{getHomepageFleetCountLabel(curatedHomepageFleet)}</span
-        >
-      </p>
-      <div class="fleet-response" aria-label="Fleet response">
-        <div class="fleet-meta">
-          <div><span>operator</span><b>matt · human</b></div><div>
-            <span>mode</span><b>human-led</b>
-          </div><div><span>runtime</span><b>ubuntu / hermes</b></div><div>
-            <span>scope</span><b>profile-backed fleet</b>
-          </div>
-        </div><div class="fleet-agents">
-          {
-            curatedHomepageFleet.map(agent => (
-              <div class="agent-row" data-agent={agent.slug}>
-                <>
-                  <span>{agent.label}</span>
-                  <b>{agent.description}</b>
-                  <span class="ok">{agent.status}</span>
-                </>
-              </div>
-            ))
-          }
+      </section>
+
+      <section class="outcome-section" id="accountability">
+        <div class="section-label">03 · ACCOUNTABILITY</div>
+        <h2>
+          Berryhill Dev is accountable for the work. Matt Berryhill is
+          accountable for the consequential calls.
+        </h2>
+        <p class="section-intro">
+          The organization owns the operating standard, the evidence trail, and
+          the quality of delivery. Matt retains authority over commercial
+          commitments, consequential decisions, and any expansion of scope or
+          risk.
+        </p>
+        <p class="callout">
+          Automation does not dilute responsibility. Every consequential action
+          remains bounded, reviewable, and attributable.
+        </p>
+        <a class="text-link" href="/about/">About Berryhill Dev and Matt →</a>
+      </section>
+
+      <section class="outcome-section" id="delivery-leverage">
+        <div class="section-label">04 · DELIVERY LEVERAGE</div>
+        <h2>
+          Agents are delivery leverage—not the product and not the authority.
+        </h2>
+        <p class="section-intro">
+          Specialized agents can research, draft, inspect, route, monitor, and
+          verify within defined roles. Clients buy an accountable operating
+          result from Berryhill Dev, not access to a cast of agents.
+        </p>
+        <div class="outcome-grid cols-3">
+          <article>
+            <h3>USEFUL FOR / Repeatable evidence work</h3><p>
+              Bounded tasks that benefit from speed, consistency, and continuous
+              inspection.
+            </p>
+          </article>
+          <article>
+            <h3>CONTROLLED BY / Explicit permissions</h3><p>
+              Data, tools, actions, escalation paths, and stop conditions are
+              defined before execution.
+            </p>
+          </article>
+          <article>
+            <h3>NEVER DELEGATED / Consequential authority</h3><p>
+              Agents do not own commercial promises, risk acceptance, or
+              decisions reserved for accountable humans.
+            </p>
+          </article>
         </div>
-      </div>
-      <div class="line">
-        <span class="ps1"
-          >guest@berryhill <span class="sep">:</span>
-          <span class="cwd">~</span> $</span
-        ><span class="cmd">cat manifesto.md</span>
-      </div>
-      <p class="out" style="padding: 8px 0 6px;">
-        <b># Manifesto</b><br />Beyond the stack lies <span class="k"
-          >the shift</span
-        > — a new cultural operating system<br />where software is grown, not
-        shipped, and the people who steer the<br />agents matter more than the
-        people who once typed the code.<br /><span class="comment"
-          ># EOF · last edit: 2026-06-02</span
-        >
-      </p>
+      </section>
+
+      <section class="outcome-section" id="methods">
+        <div class="section-label">05 · METHODS</div>
+        <h2>
+          Start with the result. Build the smallest credible system. Keep proof
+          attached.
+        </h2>
+        <p class="section-intro">
+          The method favors bounded interventions over broad transformation
+          claims and expands only when evidence supports the next decision.
+        </p>
+        <ol class="method-list">
+          <li>
+            <span>01</span><h3>Define</h3><p>
+              Name the economic result, owner, recurrence, baseline, and
+              decision threshold.
+            </p>
+          </li>
+          <li>
+            <span>02</span><h3>Bound</h3><p>
+              Specify evidence, permissions, prohibited actions, escalation, and
+              stop conditions.
+            </p>
+          </li>
+          <li>
+            <span>03</span><h3>Operate</h3><p>
+              Run the smallest read-only, draft-only, or supervised loop that
+              can create value.
+            </p>
+          </li>
+          <li>
+            <span>04</span><h3>Prove</h3><p>
+              Compare evidence to the baseline, document limitations, and decide
+              whether to expand.
+            </p>
+          </li>
+        </ol>
+      </section>
+
+      <section class="outcome-section" id="outcome-discovery">
+        <div class="section-label">06 · BOUNDED STARTING POINT</div>
+        <h2>
+          Outcome Discovery turns the problem into a bounded, decision-ready
+          starting point.
+        </h2>
+        <p class="section-intro">
+          It frames the result, current consequence, available evidence,
+          unknowns, dependencies, and prohibited information before either side
+          commits to delivery work.
+        </p>
+        <div class="outcome-grid cols-2">
+          <article>
+            <h3>01 / Frame the result</h3><p>
+              Describe what should improve, why it matters economically, who
+              owns it, and what currently happens.
+            </p>
+          </article>
+          <article>
+            <h3>02 / Protect the boundary</h3><p>
+              Do not provide credentials, customer records, regulated data,
+              production secrets, or confidential material. Initial
+              investigation is designed around non-sensitive operating context.
+            </p>
+          </article>
+          <article>
+            <h3>03 / Inspect feasibility</h3><p>
+              Berryhill Dev separates supported findings from assumptions,
+              unknowns, evidence needs, and delivery risks.
+            </p>
+          </article>
+          <article>
+            <h3>04 / Choose the next step</h3><p>
+              Receive a bounded recommendation: gather evidence, test a small
+              intervention, redirect, or stop. Delivery mechanics and privacy
+              requirements are confirmed before any subsequent work.
+            </p>
+          </article>
+        </div>
+      </section>
+
+      <section class="start-panel" id="start">
+        <div class="section-label">07 · START WITH THE ORGANIZATION</div>
+        <h2>Tell Berryhill Dev which business result needs to improve.</h2>
+        <p>
+          Bring the recurring problem, its consequence, and whatever
+          non-sensitive evidence you already have. Berryhill Dev will help
+          determine whether a bounded AI system is a credible path to a
+          measurable result.
+        </p>
+        <div class="cta-row">
+          <a class="cta primary" href="/about/#connect"
+            >Tell us what needs to improve</a
+          >
+          <a class="cta secondary" href="#proof">See how outcomes are proven</a>
+        </div>
+      </section>
+
       {
         featuredPosts.length > 0 && (
           <>
@@ -217,37 +369,298 @@ const jsonLd = buildWebSiteJsonLd({
         <h2>cat .env</h2><span class="n">contact targets</span>
       </div>
       <div class="env">
-        <a href={SITE.calendly} target="_blank" rel="noopener"
-          ><span><b>CALENDLY=</b> book/30min</span><span>schedule →</span></a
-        ><a href="mailto:matt@berryhill.dev"
+        <a href="/about/#connect"
+          ><span><b>CONNECT=</b> /about/#connect</span><span>start →</span></a
+        >
+        <a href="mailto:matt@berryhill.dev"
           ><span><b>EMAIL=</b> matt@berryhill.dev</span><span>compose →</span
           ></a
-        ><a
+        >
+        <a
           href="https://www.linkedin.com/in/matthew-berryhill/"
           target="_blank"
           rel="noopener"
           ><span><b>LINKEDIN=</b> /in/matthew-berryhill</span><span
             >connect →</span
           ></a
-        ><a href="/rss.xml"
+        >
+        <a href="/rss.xml"
           ><span><b>RSS=</b> /rss.xml</span><span>subscribe →</span></a
         >
       </div>
-      <p class="out" style="margin-top: 28px;">
+      <p class="line out end-prompt">
         <span class="ps1"
           >guest@berryhill <span class="sep">:</span>
           <span class="cwd">~</span> $</span
         >
-        <span class="cmd" id="prompt-tail"
+        <span class="cmd"
           ><span class="terminal-cursor" aria-hidden="true"></span></span
         >
       </p>
-    </div>
+    </main>
   </div>
   <footer>
-    © Berryhill 2026 · built quietly · zero trackers · <a
-      href="/rss.xml"
-      style="color: var(--muted);">rss</a
-    >
+    © Berryhill Dev 2026 · human-operated · <a href="/rss.xml">rss</a>
   </footer>
 </Layout>
+
+<style>
+  .outcome-home {
+    scroll-behavior: smooth;
+  }
+  .outcome-hero {
+    padding: clamp(22px, 4vw, 48px) 0 clamp(30px, 5vw, 56px);
+    border-bottom: 1px dashed var(--border);
+  }
+  .eyebrow,
+  .section-label {
+    color: var(--accent);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.09em;
+  }
+  .outcome-hero h1 {
+    max-width: 920px;
+    margin-top: 14px;
+    color: var(--fg);
+    font-family: var(--font-mono);
+    font-size: clamp(30px, 5.1vw, 62px);
+    font-weight: 600;
+    letter-spacing: -0.045em;
+    line-height: 1.03;
+    text-wrap: balance;
+  }
+  .outcome-hero h1 .terminal-cursor {
+    height: 0.78em;
+  }
+  .hero-deck {
+    max-width: 900px;
+    margin-top: 22px;
+    color: var(--fg);
+    font-size: clamp(14px, 1.5vw, 18px);
+    line-height: 1.65;
+  }
+  .hero-boundary {
+    max-width: 780px;
+    margin-top: 12px;
+    color: var(--muted);
+    line-height: 1.6;
+  }
+  .cta-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+    margin-top: 24px;
+  }
+  .cta {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--accent);
+    border-radius: 5px;
+    padding: 11px 16px;
+    font-weight: 700;
+    text-decoration: none;
+  }
+  .cta.primary {
+    background: var(--accent);
+    color: var(--bg);
+  }
+  .cta.secondary {
+    color: var(--accent);
+  }
+  .cta:hover,
+  .cta:focus-visible {
+    outline: 2px solid var(--info);
+    outline-offset: 2px;
+  }
+  .outcome-section {
+    scroll-margin-top: 16px;
+    padding: clamp(38px, 6vw, 72px) 0;
+    border-bottom: 1px dashed var(--border);
+  }
+  .outcome-section h2,
+  .start-panel h2 {
+    max-width: 920px;
+    margin-top: 10px;
+    color: var(--fg);
+    font-size: clamp(23px, 3vw, 38px);
+    font-weight: 600;
+    letter-spacing: -0.025em;
+    line-height: 1.18;
+    text-wrap: balance;
+  }
+  .section-intro,
+  .start-panel > p {
+    max-width: 820px;
+    margin-top: 16px;
+    color: var(--muted);
+    font-size: 14px;
+    line-height: 1.7;
+  }
+  .outcome-grid {
+    display: grid;
+    gap: 12px;
+    margin-top: 26px;
+  }
+  .outcome-grid.cols-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+  .outcome-grid.cols-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .outcome-grid article,
+  .proof-contract,
+  .method-list li {
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface);
+    padding: 18px;
+  }
+  .outcome-grid h3 {
+    margin: 0;
+    color: var(--accent);
+    font-size: 12px;
+    font-weight: 700;
+  }
+  .outcome-grid p {
+    margin-top: 10px;
+    color: var(--muted);
+    font-size: 13px;
+    line-height: 1.6;
+  }
+  .proof-contract {
+    margin-top: 26px;
+  }
+  .proof-contract > p {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    color: var(--muted);
+    font-size: 11px;
+  }
+  .proof-contract > p b,
+  .proof-contract dt {
+    color: var(--accent);
+  }
+  .proof-contract > .proof-statement {
+    display: block;
+    margin-top: 14px;
+    color: var(--fg);
+    font-size: 14px;
+    line-height: 1.6;
+  }
+  .proof-contract dl {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    margin-top: 16px;
+    background: var(--border);
+  }
+  .proof-contract dl div {
+    background: var(--surface);
+    padding: 14px;
+  }
+  .proof-contract dt {
+    font-weight: 700;
+  }
+  .proof-contract dd {
+    margin-top: 6px;
+    color: var(--muted);
+    font-size: 12px;
+  }
+  .callout {
+    max-width: 820px;
+    margin-top: 20px;
+    border-left: 3px solid var(--warn);
+    padding-left: 14px;
+    color: var(--fg);
+    line-height: 1.6;
+  }
+  .text-link {
+    display: inline-block;
+    margin-top: 20px;
+    color: var(--accent);
+  }
+  .method-list {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 12px;
+    margin-top: 26px;
+    list-style: none;
+  }
+  .method-list span {
+    color: var(--accent);
+    font-size: 11px;
+  }
+  .method-list h3 {
+    display: block;
+    margin-top: 9px;
+    color: var(--fg);
+    font-size: 17px;
+    font-weight: 700;
+  }
+  .method-list p {
+    margin-top: 9px;
+    color: var(--muted);
+    font-size: 12px;
+    line-height: 1.55;
+  }
+  .start-panel {
+    margin: clamp(38px, 6vw, 72px) 0;
+    border: 1px solid var(--accent);
+    border-radius: 7px;
+    background: linear-gradient(135deg, var(--surface), transparent);
+    padding: clamp(22px, 4vw, 38px);
+  }
+  .end-prompt {
+    margin-top: 28px;
+  }
+  footer a {
+    color: var(--muted);
+  }
+  @media (max-width: 800px) {
+    .outcome-grid.cols-3,
+    .method-list {
+      grid-template-columns: 1fr 1fr;
+    }
+    .proof-contract dl {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+  @media (max-width: 520px) {
+    .outcome-hero {
+      padding-top: 18px;
+    }
+    .outcome-hero h1 {
+      font-size: 30px;
+    }
+    .hero-deck {
+      margin-top: 16px;
+      font-size: 14px;
+      line-height: 1.55;
+    }
+    .hero-boundary {
+      font-size: 12px;
+    }
+    .cta-row {
+      margin-top: 18px;
+    }
+    .cta {
+      width: 100%;
+    }
+    .outcome-grid.cols-3,
+    .outcome-grid.cols-2,
+    .method-list,
+    .proof-contract dl {
+      grid-template-columns: 1fr;
+    }
+    .proof-contract > p {
+      flex-direction: column;
+    }
+    .outcome-section {
+      padding: 38px 0;
+    }
+  }
+</style>

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -24,8 +24,10 @@ export interface WebSiteJsonLdInput {
   url: string;
   description: string;
   image?: string;
-  author: string;
-  authorUrl?: string;
+  publisher: string;
+  publisherUrl?: string;
+  creator: string;
+  creatorUrl?: string;
 }
 
 export interface PersonJsonLdInput {
@@ -70,6 +72,14 @@ function buildPersonReference(name: string, url?: string) {
   });
 }
 
+function buildOrganizationReference(name: string, url?: string) {
+  return stripNullishValues({
+    "@type": "Organization",
+    name,
+    url,
+  });
+}
+
 export function buildBlogPostingJsonLd(input: BlogPostingJsonLdInput) {
   const author = buildPersonReference(input.author, input.authorUrl);
 
@@ -100,7 +110,8 @@ export function buildWebSiteJsonLd(input: WebSiteJsonLdInput) {
     url: input.url,
     description: input.description,
     image: input.image ? [input.image] : undefined,
-    author: buildPersonReference(input.author, input.authorUrl),
+    publisher: buildOrganizationReference(input.publisher, input.publisherUrl),
+    creator: buildPersonReference(input.creator, input.creatorUrl),
   });
 }
 

--- a/tests/homepageFleet.test.mjs
+++ b/tests/homepageFleet.test.mjs
@@ -102,21 +102,22 @@ test("curated homepage fleet excludes non-public and temporarily omitted profile
   }
 });
 
-test("displayed homepage fleet count stays aligned with curated data length", () => {
+test("curated capability data remains available without homepage telemetry claims", () => {
   assert.equal(curatedHomepageFleet.length, 9);
   assert.equal(getHomepageFleetCountLabel(), "9 verified agents");
-  assert.match(
+  assert.doesNotMatch(
     homepageSource,
-    /getHomepageFleetCountLabel\(curatedHomepageFleet\)/
+    /getHomepageFleetCountLabel|verified agents|curl GET \/fleet/
   );
-  assert.doesNotMatch(homepageSource, />8 verified agents</);
 });
 
-test("homepage renders fleet rows from the shared data structure without repeated hard-coded rows", () => {
-  assert.match(homepageSource, /curatedHomepageFleet\.map\(agent =>/);
-  assert.match(homepageSource, /data-agent=\{agent\.slug\}/);
-  assert.match(homepageSource, /<span>\{agent\.label\}<\/span>/);
-  assert.match(homepageSource, /<b>\{agent\.description\}<\/b>/);
+test("homepage frames agents only as downstream delivery leverage", () => {
+  assert.match(homepageSource, /id="delivery-leverage"/);
+  assert.match(
+    homepageSource,
+    /Agents are delivery leverage—not the product and not the authority\./
+  );
+  assert.doesNotMatch(homepageSource, /curatedHomepageFleet\.map|data-agent=/);
 });
 
 console.log(`PASS ${passed} FAIL ${failed}`);

--- a/tests/homepagePositioning.test.mjs
+++ b/tests/homepagePositioning.test.mjs
@@ -18,42 +18,117 @@ function test(name, fn) {
 function includesCollapsed(source, expected) {
   assert(source.replace(/\s+/g, " ").includes(expected));
 }
-const homepageSource = readFileSync(new URL("../src/pages/index.astro", import.meta.url), "utf8");
-const expectedSiteDescription = "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
-const prototypeAnchors = [
-  "matt<b>@berryhill</b>",
-  "builder · operator · agent conductor.",
-  "I run a fleet of specialized AI agents that design, research, code, review, write, analyze markets, and ship software with me. This site is the public terminal into that operating system.",
-  "curl GET /fleet",
-  "cat manifesto.md",
+const homepageSource = readFileSync(
+  new URL("../src/pages/index.astro", import.meta.url),
+  "utf8"
+);
+const normalizedHomepage = homepageSource.replace(/\s+/g, " ");
+const expectedSiteDescription =
+  "Field notes on AI-native discovery systems, agent governance, provenance, review gates, protocol boundaries, and the operator work required to turn agent output into shipped proof.";
+const hierarchyAnchors = [
+  'id="outcomes"',
+  "Measurable business outcomes, delivered through accountable AI systems.",
+  "Berryhill Dev builds and operates bounded AI systems",
+  'id="economic-problem"',
+  'id="proof"',
+  "Evidence remains attached to the claim it supports.",
+  'id="accountability"',
+  "Berryhill Dev is accountable for the work. Matt Berryhill is accountable for the consequential calls.",
+  'id="delivery-leverage"',
+  "Agents are delivery leverage—not the product and not the authority.",
+  'id="methods"',
+  'id="outcome-discovery"',
+  "Initial investigation is designed around non-sensitive operating context.",
+  "Delivery mechanics and privacy requirements are confirmed before any subsequent work.",
+  'id="start"',
   "ls featured/ --sort=latest",
   "ls -la recent/",
   "cat .env",
 ];
-const forbidden = ["Welcome to my corner of the internet", "Matt Berryhill builds AI-native operating systems in public.", "Terminal metaphor. Real claims only.", "Not a nicer blog. A public interface into the operating layer.", "Live fleet status", "verified telemetry"];
+const forbidden = [
+  "Welcome to my corner of the internet",
+  "Matt Berryhill builds AI-native operating systems in public.",
+  "Terminal metaphor. Real claims only.",
+  "Not a nicer blog. A public interface into the operating layer.",
+  "Live fleet status",
+  "verified telemetry",
+];
 
-test("homepage renders issue 73 prototype copy anchors", () => {
-  for (const copy of prototypeAnchors) includesCollapsed(homepageSource, copy);
-  assert.doesNotMatch(homepageSource, /ls featured\/ --sort=stars/);
+test("homepage renders the accepted organization-first outcome hierarchy in semantic order", () => {
+  for (const copy of hierarchyAnchors) includesCollapsed(homepageSource, copy);
+  const positions = hierarchyAnchors.map(copy => normalizedHomepage.indexOf(copy));
+  for (let index = 1; index < positions.length; index += 1) {
+    assert.ok(
+      positions[index] > positions[index - 1],
+      `${hierarchyAnchors[index]} must follow ${hierarchyAnchors[index - 1]}`
+    );
+  }
 });
-test("site metadata description remains approved and safe", () => {
+test("site author stays stable while homepage metadata becomes organization-first", () => {
   assert.equal(SITE.desc, expectedSiteDescription);
+  assert.equal(SITE.author, "Berryhill");
+  assert.equal(SITE.organization.name, "Berryhill Dev");
+  assert.equal(SITE.operator.name, "Matt Berryhill");
+  assert.equal(
+    SITE.homepage.description,
+    "Berryhill Dev builds and operates bounded AI systems for measurable business outcomes, with explicit evidence boundaries and human accountability."
+  );
 });
 test("homepage keeps live post mapping and reader links present", () => {
+  assert.match(homepageSource, /getLiveBlogPosts\(\)/);
+  assert.match(homepageSource, /getSortedPosts\(posts \|\| \[\]\)/);
   assert.match(homepageSource, /selectHomepagePosts\(sortedPosts\)/);
-  assert.match(homepageSource, /const \{ featuredPosts, recentPosts \} = selectHomepagePosts\(sortedPosts\);/);
+  assert.match(
+    homepageSource,
+    /const \{ featuredPosts, recentPosts \} = selectHomepagePosts\(sortedPosts\);/
+  );
   assert.match(homepageSource, /href="\/rss\.xml"/);
   assert.match(homepageSource, /href="\/posts\/"/);
   assert.match(homepageSource, /getPath\(post\.id, post\.filePath\)/);
 });
-test("homepage uses prototype terminal window contract", () => {
-  for (const cls of ["window", "titlebar", "gnome-ctrls", "tabstrip", "term", "line", "ps1", "cmd", "files", "file", "ls-row"]) {
+test("homepage keeps the existing terminal window identity", () => {
+  for (const cls of [
+    "window",
+    "titlebar",
+    "gnome-ctrls",
+    "tabstrip",
+    "term",
+    "line",
+    "ps1",
+    "cmd",
+    "files",
+    "file",
+    "ls-row",
+  ]) {
     assert.match(homepageSource, new RegExp(`class=\\"[^\\"]*${cls}`));
   }
 });
-test("homepage avoids old hybrid/product telemetry claims", () => {
-  const normalized = homepageSource.replace(/\s+/g, " ");
-  for (const term of forbidden) assert.equal(normalized.includes(term), false, `unexpected claim: ${term}`);
+test("homepage CTAs use existing boundaries and no invented routes", () => {
+  includesCollapsed(homepageSource, 'href="/about/#connect"');
+  includesCollapsed(homepageSource, "Tell us what needs to improve");
+  includesCollapsed(homepageSource, 'href="#proof"');
+  includesCollapsed(homepageSource, "See how outcomes are proven");
+  assert.doesNotMatch(homepageSource, /href="\/(?:start|outcome-discovery)\/?"/);
+  assert.doesNotMatch(homepageSource, /SITE\.calendly/);
 });
+test("homepage removes person-first positioning, fake telemetry, and command input", () => {
+  for (const stale of [
+    "matt<b>@berryhill</b>",
+    "builder · operator · agent conductor.",
+    "curl GET /fleet",
+    "cat manifesto.md",
+    "cmdbar",
+    "verified agents",
+  ]) {
+    assert.equal(homepageSource.includes(stale), false, `unexpected stale homepage anchor: ${stale}`);
+  }
+  assert.doesNotMatch(homepageSource, /<form|<input/);
+});
+test("homepage avoids old hybrid and telemetry claims", () => {
+  for (const term of forbidden) {
+    assert.equal(normalizedHomepage.includes(term), false, `unexpected claim: ${term}`);
+  }
+});
+
 console.log(`PASS ${passed} FAIL ${failed}`);
 if (failed > 0) process.exitCode = 1;

--- a/tests/structuredData.test.mjs
+++ b/tests/structuredData.test.mjs
@@ -107,15 +107,27 @@ test("WebSite produces expected type and required fields", () => {
     name: "berryhill.dev",
     url: "https://berryhill.dev/",
     description: "Exploring agentic-first development.",
-    author: "Berryhill",
-    authorUrl: "https://berryhill.dev/",
+    publisher: "Berryhill Dev",
+    publisherUrl: "https://berryhill.dev/",
+    creator: "Matt Berryhill",
+    creatorUrl: "https://berryhill.dev/about/",
   });
 
   assert.equal(jsonLd["@type"], "WebSite");
   assert.equal(jsonLd.name, "berryhill.dev");
   assert.equal(jsonLd.url, "https://berryhill.dev/");
   assert.equal(jsonLd.description, "Exploring agentic-first development.");
-  assert.equal(jsonLd.author.name, "Berryhill");
+  assert.deepEqual(jsonLd.publisher, {
+    "@type": "Organization",
+    name: "Berryhill Dev",
+    url: "https://berryhill.dev/",
+  });
+  assert.deepEqual(jsonLd.creator, {
+    "@type": "Person",
+    name: "Matt Berryhill",
+    url: "https://berryhill.dev/about/",
+  });
+  assert.equal("author" in jsonLd, false);
 });
 
 test("Person produces expected type and required fields", () => {

--- a/tests/terminalBrandSurfaces.test.mjs
+++ b/tests/terminalBrandSurfaces.test.mjs
@@ -81,10 +81,9 @@ for (const className of terminalClassContract) {
 }
 
 const exactCopyAnchors = [
-  [sources.home, "builder · operator · agent conductor."],
-  [sources.home, "I run a fleet of specialized AI agents that design, research, code, review, write, analyze markets, and ship software with me. This site is the public terminal into that operating system."],
-  [sources.home, "curl GET /fleet"],
-  [sources.home, "cat manifesto.md"],
+  [sources.home, "Measurable business outcomes, delivered through accountable AI systems."],
+  [sources.home, "Berryhill Dev builds and operates bounded AI systems"],
+  [sources.home, "Agents are delivery leverage—not the product and not the authority."],
   [sources.home, "ls featured/ --sort=latest"],
   [sources.home, "ls -la recent/"],
   [sources.home, "cat .env"],


### PR DESCRIPTION
## Summary

Replaces the person/fleet-first homepage proposition with the accepted Berryhill Dev organization-first, outcome-led narrative from the Central Foldy alignment work.

- leads with measurable business outcomes and Berryhill Dev as the accountable organization
- makes the economic problem, proof boundaries, Matt's operator accountability, and bounded agent leverage explicit
- moves Outcome Discovery downstream as one qualified starting point rather than the product/hero
- preserves live BlogStore reads, featured/recent posts, canonical post links, RSS, APIs, sitemaps, and post-specific OG behavior
- separates homepage organization/operator metadata from existing blog author/byline metadata
- removes the nonfunctional hero command input and stale person-first commercial hierarchy

## Accepted design evidence

- Current prototype: https://silas-workstation.taild7c550.ts.net:8443/api/projects/5010aa64-32a5-45dd-8857-68b5a7b03e22/raw/index.html
- Immutable prototype: https://silas-workstation.taild7c550.ts.net:8443/api/projects/5010aa64-32a5-45dd-8857-68b5a7b03e22/raw/index-organization-outcomes-20260825-r1.html
- Prototype SHA-256: `0847075545b8a7f25f77a3378e47d27ffd027d38d9a3f30a6586d70e26f563a2`
- Active contract: https://github.com/berryhill/bd-site/issues/163#issuecomment-5413282692

## Browser verification

- Desktop 1280×720: no horizontal overflow; organization label, H1, deck, accountability boundary, and primary CTA visible; primary CTA bottom `701px`
- Mobile 390×844: no horizontal overflow; organization label, H1, deck, boundary, and primary CTA visible; primary CTA bottom `600px`
- Required source order: outcome → economic problem → proof → accountability → delivery leverage → methods → Outcome Discovery → organization CTA → featured/recent writing
- Primary CTA uses the existing `/about/#connect` boundary; no invented `/start/` or `/outcome-discovery/` route and no cold Calendly link

## Validation

- `pnpm test` — pass
- `pnpm run lint` — pass
- `pnpm run format:check` — pass
- `pnpm run build` — pass
- independent specification review completed; three exact-copy gaps were repaired before commit
- independent code-quality review: approved, no blockers

Existing non-blocking advisories remain unchanged: three legacy post-title length advisories and Astro prerender request-header warnings on `/404` and `/search`.

## Path boundary

`app/source-code-touching`

Closes #163