### PR TITLE
fix(deploy): restore production GA4 configuration

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -58,9 +58,12 @@ jobs:
         with:
           context: .
           push: true
+          # BuildKit secret contents do not participate in cache keys. Force the
+          # production build step to consume the current DOT_ENV every time.
+          no-cache: true
           tags: ${{ env.DOCKER_REGISTRY }}/${{ env.DOCKER_ORG }}/${{ env.DOCKER_IMAGE }}:${{ steps.image.outputs.image_tag }}
-          build-args: |
-            DOT_ENV=${{ secrets.DOT_ENV }}
+          secrets: |
+            "dot_env=${{ secrets.DOT_ENV }}"
 
   deploy:
     needs: build-push
@@ -236,6 +239,20 @@ jobs:
               curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "https://berryhill.dev${path}" >/dev/null || POST_DEPLOY_STATUS=$?
               [ "${POST_DEPLOY_STATUS}" -eq 0 ] || break
             done
+          fi
+          if [ "${POST_DEPLOY_STATUS}" -eq 0 ]; then
+            echo "Verifying production GA4 tag"
+            HOME_HTML="$(mktemp)"
+            trap 'rm -f "${HOME_HTML}"' EXIT
+            curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 \
+              "https://berryhill.dev/" > "${HOME_HTML}" || POST_DEPLOY_STATUS=$?
+            if [ "${POST_DEPLOY_STATUS}" -eq 0 ] && \
+              ! grep -Fq 'https://www.googletagmanager.com/gtag/js?id=G-SSLPRQNE9Q' "${HOME_HTML}"; then
+              echo "Production homepage is missing the configured GA4 script tag" >&2
+              POST_DEPLOY_STATUS=1
+            fi
+            rm -f "${HOME_HTML}"
+            trap - EXIT
           fi
           if [ "${POST_DEPLOY_STATUS}" -ne 0 ]; then
             if [ -z "${PREVIOUS_REVISION}" ]; then

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,15 @@ RUN pnpm install --frozen-lockfile
 # Copy source and build
 COPY . .
 
-# Accept .env content as base64 encoded build argument and decode it
-ARG DOT_ENV
-RUN if [ -n "$DOT_ENV" ]; then echo "$DOT_ENV" | base64 -d > .env; fi
-
-RUN pnpm run build
+# Decode the base64 environment from a BuildKit secret. Build and verify in the
+# same layer so the decoded file is removed before the layer is committed.
+RUN --mount=type=secret,id=dot_env,required=true \
+    set -eu; \
+    trap 'rm -f .env' EXIT; \
+    base64 -d /run/secrets/dot_env > .env; \
+    test -s .env; \
+    pnpm run build; \
+    node scripts/verifyBuiltPublicEnv.mjs .env dist
 
 # SSR Runtime stage
 FROM node:lts-alpine AS runtime

--- a/scripts/verifyBuiltPublicEnv.mjs
+++ b/scripts/verifyBuiltPublicEnv.mjs
@@ -1,0 +1,56 @@
+/* eslint-disable no-console */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve } from "node:path";
+
+const envPath = resolve(process.argv[2] ?? ".env");
+const distPath = resolve(process.argv[3] ?? "dist");
+const requiredKeys = ["PUBLIC_GA_MEASUREMENT_ID", "PUBLIC_GOOGLE_SITE_VERIFICATION"];
+
+function fail(message) {
+  console.error(`Built public environment verification failed: ${message}`);
+  process.exit(1);
+}
+
+function parseEnv(source) {
+  const values = new Map();
+  for (const line of source.split(/\r?\n/)) {
+    const match = line.match(/^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*?)\s*$/);
+    if (!match) continue;
+
+    let value = match[2];
+    if (
+      value.length >= 2 &&
+      ((value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith("'") && value.endsWith("'")))
+    ) {
+      value = value.slice(1, -1);
+    } else {
+      value = value.replace(/\s+#.*$/, "");
+    }
+    values.set(match[1], value);
+  }
+  return values;
+}
+
+function distContains(directory, expected) {
+  for (const entry of readdirSync(directory)) {
+    const path = resolve(directory, entry);
+    if (statSync(path).isDirectory()) {
+      if (distContains(path, expected)) return true;
+    } else if (readFileSync(path).includes(expected)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+if (!existsSync(envPath)) fail("environment input is missing");
+if (!existsSync(distPath)) fail("dist output is missing");
+
+const values = parseEnv(readFileSync(envPath, "utf8"));
+for (const key of requiredKeys) {
+  const value = values.get(key);
+  if (!value) fail(`${key} is missing or empty in the build environment`);
+  if (!distContains(distPath, value)) fail(`${key} is absent from dist`);
+  console.log(`Verified ${key} is present in dist`);
+}

--- a/tests/deploymentRolloutContract.test.mjs
+++ b/tests/deploymentRolloutContract.test.mjs
@@ -48,6 +48,7 @@ const ciWorkflow = readRepoFile(".github/workflows/ci.yml");
 const values = readRepoFile("helm/values.yaml");
 const pvcTemplate = readRepoFile("helm/templates/pvc.yaml");
 const deploymentTemplate = readRepoFile("helm/templates/deployment.yaml");
+const dockerfile = readRepoFile("Dockerfile");
 const serviceAccountPath = new URL("../helm/templates/serviceaccount.yaml", import.meta.url);
 const serviceAccountTemplate = existsSync(serviceAccountPath) ? readFileSync(serviceAccountPath, "utf8") : "";
 
@@ -128,6 +129,17 @@ test("main deployment builds and pushes a SHA tag while exporting its immutable 
   assert.doesNotMatch(workflow, /docker build/);
   assert.doesNotMatch(workflow, /docker push/);
   assert.doesNotMatch(workflow, /DOCKER_TAG:\s*0\.0\.56/);
+});
+
+test("production build delivers DOT_ENV as a required secret and fails closed on public build values", () => {
+  assert.match(workflow, /secrets:\s*\|\s*"dot_env=\$\{\{ secrets\.DOT_ENV \}\}"/);
+  assert.match(workflow, /no-cache:\s*true/);
+  assert.doesNotMatch(workflow, /build-args:[\s\S]*DOT_ENV=/);
+  assert.match(dockerfile, /--mount=type=secret,id=dot_env,required=true/);
+  assert.match(dockerfile, /base64 -d \/run\/secrets\/dot_env > \.env/);
+  assert.match(dockerfile, /test -s \.env/);
+  assert.match(dockerfile, /node scripts\/verifyBuiltPublicEnv\.mjs \.env dist/);
+  assert.match(dockerfile, /trap 'rm -f \.env' EXIT/);
 });
 
 test("preflight and Helm deploy the exact build digest while retaining SHA revision metadata", () => {
@@ -226,6 +238,11 @@ test("post-rollout public checks are bounded and roll back to the verified previ
   assert.match(workflow, /helm rollback bd-site "\$\{PREVIOUS_REVISION\}" -n "\$\{KUBE_NAMESPACE\}" --wait --timeout 3m/);
   assert.match(workflow, /kubectl rollout status deployment\/bd-site -n "\$\{KUBE_NAMESPACE\}" --timeout=180s/);
   assert.doesNotMatch(workflow, /curl -fsS https:\/\/berryhill\.dev\/posts\/ >\/dev\/null \|\| true/);
+  assert.match(
+    workflow,
+    /grep -Fq 'https:\/\/www\.googletagmanager\.com\/gtag\/js\?id=G-SSLPRQNE9Q'/
+  );
+  assert.match(workflow, /Production homepage is missing the configured GA4 script tag/);
 });
 
 test("Helm rollout is atomic and all namespaced operations specify the production namespace", () => {


### PR DESCRIPTION
## Summary
- pass DOT_ENV to Docker as a required BuildKit secret instead of a build argument
- fail the image build unless the configured GA4 and Google verification public values are present in dist
- disable production build caching so BuildKit cannot reuse output for stale secret contents
- fail and roll back deployment when the live homepage omits the configured GA4 loader

## Path boundary
- deployment-touching

## Verification
- pnpm test
- pnpm run lint
- pnpm run format:check
- pnpm run build
- git diff --check
- fresh no-cache Docker build with synthetic BuildKit secret
- final image has no /app/.env and contains both synthetic public values in /app/dist
- independent deployment/security review: no blocking findings

No secret values are printed or committed.

Closes #181