### PR TITLE
feat: add stateless Helm and runtime operation

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -20,6 +20,8 @@ env:
   DOCKER_IMAGE: bd-site-app
   GHCR_PULL_SECRET: ghcr-pull
   GHCR_PREFLIGHT_SECRET: ghcr-pull-preflight
+  DOPPLER_RUNTIME_SECRET: bd-site-doppler
+  DOPPLER_RUNTIME_SECRET_KEY: token
   PREFLIGHT_NAME: bd-site-image-preflight
   KUBE_NAMESPACE: default
 
@@ -183,9 +185,24 @@ jobs:
             --from-file=.dockerconfigjson="${DOCKER_CONFIG_PATH}" \
             --dry-run=client -o yaml | kubectl apply -n "${KUBE_NAMESPACE}" -f -
 
-      - name: Deploy exact built image using Helm
+      - name: Reconcile Doppler runtime secret
         env:
           DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
+          DOPPLER_TOKEN_PATH: ${{ runner.temp }}/doppler-token
+        run: |
+          if [ -z "${DOPPLER_TOKEN}" ]; then
+            echo "DOPPLER_TOKEN is required for the production runtime" >&2
+            exit 1
+          fi
+          umask 077
+          printf '%s' "${DOPPLER_TOKEN}" > "${DOPPLER_TOKEN_PATH}"
+          chmod 600 "${DOPPLER_TOKEN_PATH}"
+          kubectl create secret generic "${DOPPLER_RUNTIME_SECRET}" -n "${KUBE_NAMESPACE}" \
+            --from-file="${DOPPLER_RUNTIME_SECRET_KEY}=${DOPPLER_TOKEN_PATH}" \
+            --dry-run=client -o yaml | kubectl apply -n "${KUBE_NAMESPACE}" -f -
+
+      - name: Deploy exact built image using Helm
+        env:
           IMAGE_TAG: ${{ needs.build-push.outputs.image-tag }}
           IMAGE_DIGEST: ${{ needs.build-push.outputs.image-digest }}
         run: |
@@ -202,7 +219,6 @@ jobs:
 
           set +e
           helm upgrade --install bd-site ./helm -n "${KUBE_NAMESPACE}" -f ./helm/values.yaml \
-            --set dopplerToken="${DOPPLER_TOKEN}" \
             --set image.tag="${IMAGE_TAG}" \
             --set image.digest="${IMAGE_DIGEST}" \
             --set deploymentRevision="${GITHUB_SHA}" \
@@ -233,6 +249,20 @@ jobs:
             POST_DEPLOY_STATUS=1
           fi
 
+          if [ "${POST_DEPLOY_STATUS}" -eq 0 ]; then
+            LIVEZ_BODY="$(curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "https://berryhill.dev/livez")" || POST_DEPLOY_STATUS=$?
+            if [ "${POST_DEPLOY_STATUS}" -eq 0 ] && ! printf '%s' "${LIVEZ_BODY}" | grep -Fq '"status":"alive"'; then
+              echo "Production /livez did not report process liveness" >&2
+              POST_DEPLOY_STATUS=1
+            fi
+          fi
+          if [ "${POST_DEPLOY_STATUS}" -eq 0 ]; then
+            READYZ_BODY="$(curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "https://berryhill.dev/readyz")" || POST_DEPLOY_STATUS=$?
+            if [ "${POST_DEPLOY_STATUS}" -eq 0 ] && ! printf '%s' "${READYZ_BODY}" | grep -Fq '"status":"ready"'; then
+              echo "Production /readyz did not report storage readiness" >&2
+              POST_DEPLOY_STATUS=1
+            fi
+          fi
           if [ "${POST_DEPLOY_STATUS}" -eq 0 ]; then
             for path in "/" "/posts/" "/rss.xml" "/sitemap.xml" "/sitemap-posts.xml"; do
               echo "Verifying https://berryhill.dev${path}"
@@ -274,6 +304,13 @@ jobs:
           kubectl delete daemonset "${PREFLIGHT_NAME}" -n "${KUBE_NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
           kubectl delete secret "${GHCR_PREFLIGHT_SECRET}" -n "${KUBE_NAMESPACE}" --ignore-not-found --wait=false >/dev/null 2>&1 || true
           rm -f "${DOCKER_CONFIG_PATH}"
+
+      - name: Cleanup temporary credential files
+        if: always()
+        env:
+          DOPPLER_TOKEN_PATH: ${{ runner.temp }}/doppler-token
+        run: |
+          rm -f "${DOPPLER_TOKEN_PATH}"
 
       - name: Deployment diagnostics
         if: always()

--- a/API.md
+++ b/API.md
@@ -48,7 +48,29 @@ curl https://berryhill.dev/api/auth/validate \
   -H "x-api-key: YOUR_API_KEY"
 ```
 
-## 2. Health Check
+## 2. Runtime Probes
+
+Kubernetes and deployment automation use two unauthenticated, exact-path JSON
+probes. These machine endpoints do not redirect to slash-suffixed URLs:
+
+- `GET` or `HEAD /livez` checks only that the application process can answer.
+  It returns `200` with `Cache-Control: no-store` while the process is alive,
+  even if the selected object store is temporarily unavailable.
+- `GET` or `HEAD /readyz` checks the selected primary store, catalog generation,
+  admitted migration state, and writer epoch without falling back to a mirror
+  secondary. It returns `200` when ready or `503` with
+  `Cache-Control: no-store` and `Retry-After: 30` when unavailable.
+
+These probes intentionally expose bounded, non-secret diagnostics and require
+no API key. Use authenticated `/api/health` when validating API credentials or
+requesting the API-oriented storage status response.
+
+Production injects `DOPPLER_TOKEN` through a Kubernetes `secretKeyRef`. Helm
+values and API diagnostics contain only the non-secret Secret name/key
+selectors; credential values must not be passed through Helm arguments,
+rendered manifests, probe responses, or troubleshooting output.
+
+## 3. Authenticated Health Check
 
 Verify the API connection is working and validate your API key.
 
@@ -100,7 +122,7 @@ failures without returning internal configuration or provider error details.
 }
 ```
 
-## 3. Get Posts
+## 4. Get Posts
 
 Retrieve a list of blog posts with optional filtering.
 
@@ -145,7 +167,7 @@ x-api-key: YOUR_API_KEY
 }
 ```
 
-## 4. Create Post
+## 5. Create Post
 
 Create a new blog post.
 
@@ -324,7 +346,7 @@ With a URL input, the command verifies `<title>`, meta description, Open Graph t
 }
 ```
 
-## 5. Update Post
+## 6. Update Post
 
 Update an existing blog post's metadata or content.
 
@@ -526,7 +548,7 @@ curl --fail --silent --show-error -X PATCH "${BASE_URL}/api/posts" \
 }
 ```
 
-## 6. Delete Post
+## 7. Delete Post
 
 Delete a blog post by slug.
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -32,26 +32,33 @@ doppler secrets set PUBLIC_GA_MEASUREMENT_ID="G-XXXXXXXXXX"
 In Doppler dashboard:
 1. Go to your project → Access
 2. Create a **Service Token** for production
-3. Copy the token (starts with `dp.st.`)
+3. Store the token through approved credential custody; do not add it to this repository
 
 ## Deploy to Kubernetes
 
-### Method 1: Using Helm Values File
+### Method 1: Use the runtime Kubernetes Secret
 
-Create `helm/values.prod.yaml`:
+The Deployment reads `DOPPLER_TOKEN` from the `bd-site-doppler` Secret's
+`token` key. Reconcile that Secret from an approved protected credential file;
+do not put the token in a values file, Helm argument, rendered manifest, or
+shell output:
 
-```yaml
-dopplerToken: "dp.st.prod.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```bash
+DOPPLER_TOKEN_PATH=/path/to/protected/doppler-token
+test -s "${DOPPLER_TOKEN_PATH}"
+test "$(stat -c '%a' "${DOPPLER_TOKEN_PATH}")" = "600"
+kubectl create secret generic bd-site-doppler \
+  --from-file="token=${DOPPLER_TOKEN_PATH}" \
+  --dry-run=client -o yaml | kubectl apply -f -
 ```
 
-Deploy:
+Then deploy only non-secret values through Helm:
 
 ```bash
 REVISION="$(git rev-parse HEAD)"
 
 helm upgrade --install bd-site ./helm \
   -f helm/values.yaml \
-  -f helm/values.prod.yaml \
   --set image.tag="${REVISION}" \
   --set deploymentRevision="${REVISION}" \
   --namespace default
@@ -67,7 +74,10 @@ The chart defaults to the current filesystem-backed production behavior:
 
 ```yaml
 contentStorage:
+  mode: filesystem
+  multiReplicaConcurrencySafe: false
   filesystem:
+    directory: /app/src/data/blog
     pvc:
       create: true
       mount: true
@@ -75,7 +85,37 @@ contentStorage:
       preserveOnDelete: true
 ```
 
-`create` controls whether Helm renders the PVC. `mount` independently controls whether the Deployment renders `/app/src/data/blog` as a `volumeMount` and matching PVC volume. With `create: true` and `mount: false`, Helm preserves the claim as a rollback source but the application pod has no posts-content volume. The chart never substitutes `emptyDir` when mounting is disabled. Set `create: false` only when `existingClaim` is managed outside this release.
+`mode` controls storage and rollout behavior. `filesystem`, `filesystem-mirror`, and `object-mirror` require exactly one replica and use `Recreate`; by default they mount the retained claim. `object` keeps the PVC resource but renders no content `volumeMount`, content volume, or `emptyDir`; it uses `RollingUpdate` with `maxUnavailable: 0` and `maxSurge: 1`. `create` controls whether Helm renders the PVC, while `mount` independently controls whether filesystem-backed modes attach it. With `create: true` and `mount: false`, Helm retains the rollback claim but renders no posts content mount, volume, or `emptyDir`. Set `create: false` only when `existingClaim` is managed outside this release.
+
+Object mode still defaults to one replica. A replica count above one fails chart rendering unless `contentStorage.multiReplicaConcurrencySafe=true` is set explicitly after the object-store concurrency contract has passed. Filesystem and mirror modes reject every replica count other than one.
+
+The Deployment sends process-only liveness and startup probes to the exact, unsuffixed `/livez` path. Storage outages therefore remove a pod from service through the exact `/readyz` path without creating liveness restart storms. Both routes are unauthenticated JSON machine endpoints, bypass canonical HTML redirects, and set `Cache-Control: no-store`; `/readyz` also returns `Retry-After: 30` when unavailable. `/readyz` checks only the configured primary store; mirror readiness never falls back to the secondary. It also checks the admitted migration state, writer epoch, and optional expected object-catalog generation. Non-secret readiness diagnostics include storage mode, catalog generation, CAS-conflict count, mirror lag, parity mismatch, write-freeze state, and restore timestamp. Authenticated `/api/health` remains the API credential and API-oriented storage-status check; it is not used for Kubernetes probes.
+
+The following values are non-secret runtime wiring. The Doppler Secret name and
+key are selectors, not credential values. Object credentials remain
+Doppler/runtime-only and must not be added to values files:
+
+```yaml
+runtimeSecrets:
+  doppler:
+    name: bd-site-doppler
+    key: token
+contentStorage:
+  object:
+    bucket: ""
+    prefix: bd-site/content/v1
+    region: ""
+    endpoint: ""
+    forcePathStyle: false
+    requestTimeoutMs: 5000
+    maxAttempts: 3
+  migration:
+    state: steady
+    requiredState: steady
+    writerEpoch: "1"
+    requiredWriterEpoch: "1"
+    expectedCatalogGeneration: ""
+```
 
 `preserveOnDelete: true` applies `helm.sh/resource-policy: keep` to a chart-created PVC. That protects the claim from Helm deletion; the backing PV remains governed by its Kubernetes reclaim policy. Before any object-storage migration, use credential-safe metadata readback and require `Retain`:
 
@@ -89,13 +129,17 @@ kubectl get pv "${PV_NAME}" -o jsonpath='{.metadata.name}{"\t"}{.spec.persistent
 
 If the policy is not `Retain`, stop before migration and route the policy change to the cluster operator. Do not print kubeconfig, Doppler values, or Kubernetes Secret content as verification.
 
-### Method 2: Using Helm CLI Argument
+### Method 2: Select an operator-managed runtime Secret
+
+If an operator uses a differently named Secret or key, pass only those
+non-secret selectors to Helm. The referenced Secret must already exist:
 
 ```bash
 REVISION="$(git rev-parse HEAD)"
 
 helm upgrade --install bd-site ./helm \
-  --set dopplerToken="dp.st.prod.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
+  --set runtimeSecrets.doppler.name="operator-managed-doppler" \
+  --set runtimeSecrets.doppler.key="token" \
   --set image.tag="${REVISION}" \
   --set deploymentRevision="${REVISION}" \
   --namespace default
@@ -161,14 +205,11 @@ The `ENV` environment variable controls the mode:
 ### Check if Doppler is working in container:
 
 ```bash
-# Exec into pod
-kubectl exec -it <pod-name> -- sh
-
-# Verify Doppler token
-echo $DOPPLER_TOKEN
-
-# Test Doppler CLI
-doppler secrets
+# Verify the Secret reference and runtime injection without reading the value
+kubectl get secret bd-site-doppler
+kubectl get deployment bd-site \
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="DOPPLER_TOKEN")].valueFrom.secretKeyRef}{"\n"}'
+kubectl exec deployment/bd-site -- sh -c 'test -n "${DOPPLER_TOKEN:-}"'
 ```
 
 ### Check application logs:
@@ -193,6 +234,8 @@ kubectl rollout status deployment/bd-site --timeout=180s
 kubectl get pods -l app=bd-site -o wide
 
 # Live crawl/social-preview checks after rollout completion
+curl -fsS https://berryhill.dev/livez | grep -Fq '"status":"alive"'
+curl -fsS https://berryhill.dev/readyz | grep -Fq '"status":"ready"'
 curl -fsS https://berryhill.dev/robots.txt | grep -A2 '^User-agent: Twitterbot$'
 curl -fsSI https://berryhill.dev/posts/<post-slug>/index.png
 pnpm run check:social-preview -- https://berryhill.dev/posts/<post-slug>/

--- a/helm/examples/deployment-recreate.yaml
+++ b/helm/examples/deployment-recreate.yaml
@@ -28,7 +28,10 @@ spec:
               protocol: TCP
           env:
             - name: DOPPLER_TOKEN
-              value: {{ .Values.dopplerToken }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.runtimeSecrets.doppler.name | quote }}
+                  key: {{ .Values.runtimeSecrets.doppler.key | quote }}
           {{- if .Values.contentStorage.filesystem.pvc.mount }}
           volumeMounts:
             - name: posts-content

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -1,3 +1,16 @@
+{{- $mode := .Values.contentStorage.mode -}}
+{{- $validModes := list "filesystem" "object" "filesystem-mirror" "object-mirror" -}}
+{{- if not (has $mode $validModes) -}}
+{{- fail (printf "contentStorage.mode must be one of filesystem, object, filesystem-mirror, object-mirror; got %q" $mode) -}}
+{{- end -}}
+{{- $usesFilesystem := ne $mode "object" -}}
+{{- $mountsFilesystem := and $usesFilesystem .Values.contentStorage.filesystem.pvc.mount -}}
+{{- if and $usesFilesystem (ne (int .Values.replicaCount) 1) -}}
+{{- fail (printf "contentStorage.mode %s requires replicaCount=1 because it is filesystem-backed" $mode) -}}
+{{- end -}}
+{{- if and (gt (int .Values.replicaCount) 1) (not .Values.contentStorage.multiReplicaConcurrencySafe) -}}
+{{- fail "replicaCount above one requires contentStorage.mode=object and contentStorage.multiReplicaConcurrencySafe=true" -}}
+{{- end -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,9 +18,16 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
+    {{- if eq $mode "object" }}
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+    {{- else }}
     # A single ReadWriteOnce posts volume cannot safely support overlapping
     # old/new pods when Kubernetes schedules them on different nodes.
     type: Recreate
+    {{- end }}
   selector:
     matchLabels:
       app: {{ .Values.service.name }}
@@ -31,11 +51,52 @@ spec:
               protocol: TCP
           env:
             - name: DOPPLER_TOKEN
-              value: {{ .Values.dopplerToken | quote }}
-          {{- if .Values.contentStorage.filesystem.pvc.mount }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.runtimeSecrets.doppler.name | quote }}
+                  key: {{ .Values.runtimeSecrets.doppler.key | quote }}
+            - name: CONTENT_STORAGE_MODE
+              value: {{ $mode | quote }}
+            - name: CONTENT_STORAGE_FILESYSTEM_PATH
+              value: {{ .Values.contentStorage.filesystem.directory | quote }}
+            - name: CONTENT_OBJECT_BUCKET
+              value: {{ .Values.contentStorage.object.bucket | quote }}
+            - name: CONTENT_OBJECT_PREFIX
+              value: {{ .Values.contentStorage.object.prefix | quote }}
+            - name: CONTENT_OBJECT_REGION
+              value: {{ .Values.contentStorage.object.region | quote }}
+            - name: CONTENT_OBJECT_ENDPOINT
+              value: {{ .Values.contentStorage.object.endpoint | quote }}
+            - name: CONTENT_OBJECT_FORCE_PATH_STYLE
+              value: {{ .Values.contentStorage.object.forcePathStyle | quote }}
+            - name: CONTENT_OBJECT_REQUEST_TIMEOUT_MS
+              value: {{ .Values.contentStorage.object.requestTimeoutMs | quote }}
+            - name: CONTENT_OBJECT_MAX_ATTEMPTS
+              value: {{ .Values.contentStorage.object.maxAttempts | quote }}
+            - name: CONTENT_OBJECT_CATALOG_CAS_RETRIES
+              value: {{ .Values.contentStorage.object.catalogCasRetries | quote }}
+            - name: CONTENT_MIGRATION_STATE
+              value: {{ .Values.contentStorage.migration.state | quote }}
+            - name: CONTENT_MIGRATION_REQUIRED_STATE
+              value: {{ .Values.contentStorage.migration.requiredState | quote }}
+            - name: CONTENT_WRITER_EPOCH
+              value: {{ .Values.contentStorage.migration.writerEpoch | quote }}
+            - name: CONTENT_WRITER_REQUIRED_EPOCH
+              value: {{ .Values.contentStorage.migration.requiredWriterEpoch | quote }}
+            - name: CONTENT_CATALOG_EXPECTED_GENERATION
+              value: {{ .Values.contentStorage.migration.expectedCatalogGeneration | quote }}
+            - name: CONTENT_WRITE_FROZEN
+              value: {{ .Values.contentStorage.migration.writeFrozen | quote }}
+            - name: CONTENT_MIRROR_LAG
+              value: {{ .Values.contentStorage.migration.mirrorLag | quote }}
+            - name: CONTENT_PARITY_MISMATCH
+              value: {{ .Values.contentStorage.migration.parityMismatch | quote }}
+            - name: CONTENT_RESTORE_TIMESTAMP
+              value: {{ .Values.contentStorage.migration.restoreTimestamp | quote }}
+          {{- if $mountsFilesystem }}
           volumeMounts:
             - name: posts-content
-              mountPath: /app/src/data/blog
+              mountPath: {{ .Values.contentStorage.filesystem.directory }}
           {{- end }}
           lifecycle:
             preStop:
@@ -43,7 +104,7 @@ spec:
                 command: ["/bin/sh", "-c", "sleep 15"]
           readinessProbe:
             httpGet:
-              path: /
+              path: /readyz
               port: {{ .Values.service.targetPort }}
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -52,14 +113,21 @@ spec:
             failureThreshold: 3
           livenessProbe:
             httpGet:
-              path: /
+              path: /livez
               port: {{ .Values.service.targetPort }}
             initialDelaySeconds: 15
             periodSeconds: 10
             timeoutSeconds: 3
             successThreshold: 1
             failureThreshold: 3
-      {{- if .Values.contentStorage.filesystem.pvc.mount }}
+          startupProbe:
+            httpGet:
+              path: /livez
+              port: {{ .Values.service.targetPort }}
+            periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 24
+      {{- if $mountsFilesystem }}
       volumes:
         - name: posts-content
           persistentVolumeClaim:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -27,10 +27,21 @@ ingress:
   host: berryhill.dev
   name: bd-site
 
-dopplerToken: ""
+runtimeSecrets:
+  doppler:
+    # The workflow reconciles this Secret out of band; Helm renders selectors only.
+    name: bd-site-doppler
+    key: token
 
 contentStorage:
+  # Production remains filesystem-backed until the separately gated cutover.
+  # Supported values: filesystem, object, filesystem-mirror, object-mirror.
+  mode: filesystem
+  # Object mode may scale above one replica only after the object-store
+  # concurrency contract has been explicitly admitted by the operator.
+  multiReplicaConcurrencySafe: false
   filesystem:
+    directory: /app/src/data/blog
     pvc:
       # Creation and mounting are independent so object-mode preparation can
       # retain the rollback claim without attaching it to the application pod.
@@ -41,3 +52,22 @@ contentStorage:
       size: 25Gi
       storageClassName: ""  # Use default storage class
       accessMode: ReadWriteOnce  # Linode Block Storage only supports ReadWriteOnce
+  object:
+    bucket: ""
+    prefix: bd-site/content/v1
+    region: ""
+    endpoint: ""
+    forcePathStyle: false
+    requestTimeoutMs: 5000
+    maxAttempts: 3
+    catalogCasRetries: 128
+  migration:
+    state: steady
+    requiredState: steady
+    writerEpoch: "1"
+    requiredWriterEpoch: "1"
+    expectedCatalogGeneration: ""
+    writeFrozen: false
+    mirrorLag: 0
+    parityMismatch: false
+    restoreTimestamp: ""

--- a/src/content/runtimeReadiness.ts
+++ b/src/content/runtimeReadiness.ts
@@ -1,0 +1,168 @@
+import { BlogStoreUnavailableError } from "@/content/blogStore";
+import {
+  getBlogStore,
+  getBlogStoreDiagnostics,
+} from "@/content/blogStoreFactory";
+
+const generationFromIdentity = (identity?: string) => {
+  const match = identity?.match(/^object-catalog:(\d+)$/);
+  return match ? Number(match[1]) : null;
+};
+
+const diagnosticBoolean = (value: string | undefined) => value === "true";
+
+const admittedWriteFrozen = (value: string | undefined) => {
+  if (value === undefined || value === "false") return false;
+  if (value === "true") return true;
+  return null;
+};
+
+const diagnosticInteger = (value: string | undefined) => {
+  const candidate = value ?? "0";
+  if (!/^(0|[1-9]\d{0,9})$/.test(candidate)) return 0;
+  return Number(candidate);
+};
+
+const MIGRATION_STATES = new Set([
+  "steady",
+  "mirroring",
+  "cutover",
+  "rollback",
+  "restoring",
+]);
+
+const diagnosticMigrationState = (value: string | undefined) => {
+  const candidate = value ?? "steady";
+  return MIGRATION_STATES.has(candidate) ? candidate : null;
+};
+
+const diagnosticWriterEpoch = (value: string | undefined) => {
+  const candidate = value ?? "1";
+  if (!/^(0|[1-9]\d{0,15})$/.test(candidate)) return null;
+  return Number.isSafeInteger(Number(candidate)) ? candidate : null;
+};
+
+const diagnosticRestoreTimestamp = (value: string | undefined) => {
+  if (!value) return null;
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/.test(value)) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  const normalizedInput = value.includes(".")
+    ? value
+    : value.replace(/Z$/, ".000Z");
+  return parsed.toISOString() === normalizedInput ? parsed.toISOString() : null;
+};
+
+const admittedRuntimeIdentity = () => {
+  const migrationState = diagnosticMigrationState(
+    process.env.CONTENT_MIGRATION_STATE
+  );
+  const requiredMigrationState = diagnosticMigrationState(
+    process.env.CONTENT_MIGRATION_REQUIRED_STATE
+  );
+  if (!migrationState || !requiredMigrationState) {
+    throw new BlogStoreUnavailableError(
+      "Content migration state is not admitted"
+    );
+  }
+
+  const writerEpoch = diagnosticWriterEpoch(process.env.CONTENT_WRITER_EPOCH);
+  const requiredWriterEpoch = diagnosticWriterEpoch(
+    process.env.CONTENT_WRITER_REQUIRED_EPOCH
+  );
+  if (!writerEpoch || !requiredWriterEpoch) {
+    throw new BlogStoreUnavailableError("Content writer epoch is not admitted");
+  }
+
+  return {
+    migrationState,
+    requiredMigrationState,
+    writerEpoch,
+    requiredWriterEpoch,
+  };
+};
+
+let casConflicts = 0;
+
+export function recordContentCasConflict() {
+  casConflicts += 1;
+}
+
+export function assertContentWriteAdmitted() {
+  const writeFrozen = admittedWriteFrozen(process.env.CONTENT_WRITE_FROZEN);
+  if (writeFrozen === null) {
+    throw new BlogStoreUnavailableError(
+      "Content write-freeze state is not admitted"
+    );
+  }
+  if (writeFrozen) {
+    throw new BlogStoreUnavailableError("Content writes are frozen");
+  }
+  const {
+    migrationState,
+    requiredMigrationState,
+    writerEpoch,
+    requiredWriterEpoch,
+  } = admittedRuntimeIdentity();
+  if (migrationState !== requiredMigrationState) {
+    throw new BlogStoreUnavailableError(
+      "Content migration state is not admitted"
+    );
+  }
+  if (writerEpoch !== requiredWriterEpoch) {
+    throw new BlogStoreUnavailableError("Content writer epoch is not admitted");
+  }
+}
+
+export async function getContentReadiness() {
+  const {
+    migrationState,
+    requiredMigrationState,
+    writerEpoch,
+    requiredWriterEpoch,
+  } = admittedRuntimeIdentity();
+  const expectedGenerationValue =
+    process.env.CONTENT_CATALOG_EXPECTED_GENERATION?.trim();
+
+  if (migrationState !== requiredMigrationState) {
+    throw new BlogStoreUnavailableError(
+      "Content migration state is not admitted"
+    );
+  }
+  if (writerEpoch !== requiredWriterEpoch) {
+    throw new BlogStoreUnavailableError("Content writer epoch is not admitted");
+  }
+
+  const store = getBlogStore();
+  await store.ready();
+  const snapshot = await store.snapshot();
+  const catalogGeneration = generationFromIdentity(snapshot.identity);
+  if (expectedGenerationValue) {
+    const expectedGeneration = Number(expectedGenerationValue);
+    if (
+      !Number.isSafeInteger(expectedGeneration) ||
+      expectedGeneration < 0 ||
+      catalogGeneration !== expectedGeneration
+    ) {
+      throw new BlogStoreUnavailableError(
+        "Content catalog generation is not admitted"
+      );
+    }
+  }
+
+  return {
+    ...getBlogStoreDiagnostics(),
+    catalogGeneration,
+    migrationState,
+    writerEpoch,
+    casConflicts,
+    writeFrozen: diagnosticBoolean(process.env.CONTENT_WRITE_FROZEN),
+    mirrorLag: diagnosticInteger(process.env.CONTENT_MIRROR_LAG),
+    parityMismatch: diagnosticBoolean(process.env.CONTENT_PARITY_MISMATCH),
+    restoreTimestamp: diagnosticRestoreTimestamp(
+      process.env.CONTENT_RESTORE_TIMESTAMP
+    ),
+  };
+}

--- a/src/pages/api/posts.ts
+++ b/src/pages/api/posts.ts
@@ -15,6 +15,10 @@ import {
   resolveCreatePubDatetime,
 } from "@/content/blogSchema";
 import { getBlogStore } from "@/content/blogStoreFactory";
+import {
+  assertContentWriteAdmitted,
+  recordContentCasConflict,
+} from "@/content/runtimeReadiness";
 import { resolveUpdateModDatetime } from "@/content/blogMutation";
 import { SITE } from "@/config";
 import { submitPublicPostCrawlSignals } from "@/utils/publicPostCrawlSignals";
@@ -106,6 +110,7 @@ const storageErrorResponse = (error: unknown, action: string) => {
     );
   }
   if (error instanceof BlogStoreConflictError) {
+    recordContentCasConflict();
     return jsonResponse(
       { error: "Post storage conflict", details: error.message },
       409
@@ -297,6 +302,11 @@ export const POST: APIRoute = async context => {
   // Validate API key
   const authError = requireApiKey(context);
   if (authError) return authError;
+  try {
+    assertContentWriteAdmitted();
+  } catch (error) {
+    return storageErrorResponse(error, "create post");
+  }
 
   try {
     const { request } = context;
@@ -441,6 +451,11 @@ export const PATCH: APIRoute = async context => {
   // Validate API key
   const authError = requireApiKey(context);
   if (authError) return authError;
+  try {
+    assertContentWriteAdmitted();
+  } catch (error) {
+    return storageErrorResponse(error, "update post");
+  }
 
   try {
     const { request } = context;
@@ -623,6 +638,11 @@ export const PATCH: APIRoute = async context => {
 export const DELETE: APIRoute = async context => {
   const authError = requireApiKey(context);
   if (authError) return authError;
+  try {
+    assertContentWriteAdmitted();
+  } catch (error) {
+    return storageErrorResponse(error, "delete post");
+  }
 
   try {
     const searchParams = new URL(context.url).searchParams;

--- a/src/pages/livez.ts
+++ b/src/pages/livez.ts
@@ -1,0 +1,12 @@
+import type { APIRoute } from "astro";
+
+export const prerender = false;
+
+export const GET: APIRoute = () =>
+  new Response(JSON.stringify({ status: "alive" }), {
+    status: 200,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });

--- a/src/pages/readyz.ts
+++ b/src/pages/readyz.ts
@@ -1,0 +1,32 @@
+import type { APIRoute } from "astro";
+import { getContentReadiness } from "@/content/runtimeReadiness";
+
+export const prerender = false;
+
+export const GET: APIRoute = async () => {
+  try {
+    const storage = await getContentReadiness();
+    return new Response(
+      JSON.stringify({ status: "ready", storage: { ...storage, ready: true } }),
+      {
+        status: 200,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+        },
+      }
+    );
+  } catch {
+    return new Response(
+      JSON.stringify({ status: "unavailable", storage: { ready: false } }),
+      {
+        status: 503,
+        headers: {
+          "Content-Type": "application/json",
+          "Cache-Control": "no-store",
+          "Retry-After": "30",
+        },
+      }
+    );
+  }
+};

--- a/src/utils/url.ts
+++ b/src/utils/url.ts
@@ -1,6 +1,7 @@
 const DEFAULT_WEBSITE = "https://berryhill.dev/";
 const FILE_EXTENSION_PATH_RE = /\/[^/]+\.[^/]+$/;
 const CANONICAL_HTML_REDIRECT_METHODS = new Set(["GET", "HEAD"]);
+const RUNTIME_PROBE_PATHS = new Set(["/livez", "/readyz"]);
 const PAGE_ONE_ARCHIVE_PATH_RE = /^\/posts\/page\/1\/?$/;
 const PAGE_ONE_ARCHIVE_TARGET = "/posts/";
 
@@ -30,6 +31,10 @@ function isApiPath(pathname: string) {
   return pathname === "/api" || pathname.startsWith("/api/");
 }
 
+function isRuntimeProbePath(pathname: string) {
+  return RUNTIME_PROBE_PATHS.has(pathname);
+}
+
 export function isFileLikePathname(pathname: string): boolean {
   return FILE_EXTENSION_PATH_RE.test(pathname);
 }
@@ -39,12 +44,18 @@ export function shouldEnforceTrailingSlash(pathname: string): boolean {
     pathname !== "/" &&
     !pathname.endsWith("/") &&
     !isApiPath(pathname) &&
+    !isRuntimeProbePath(pathname) &&
     !isFileLikePathname(pathname)
   );
 }
 
 export function getAlternateHtmlPathname(pathname: string): string | null {
-  if (pathname === "/" || isApiPath(pathname) || isFileLikePathname(pathname)) {
+  if (
+    pathname === "/" ||
+    isApiPath(pathname) ||
+    isRuntimeProbePath(pathname) ||
+    isFileLikePathname(pathname)
+  ) {
     return null;
   }
 

--- a/tests/blogHealthApiRoute.test.mjs
+++ b/tests/blogHealthApiRoute.test.mjs
@@ -73,6 +73,25 @@ async function readHealth(origin, apiKey) {
   return { response, body: await response.json() };
 }
 
+async function readProbe(origin, pathname, options = {}) {
+  const headers = options.accept ? { accept: options.accept } : {};
+  const response = await fetch(new URL(pathname, origin), {
+    method: options.method ?? "GET",
+    headers,
+    redirect: "manual",
+  });
+  const text = await response.text();
+  return { response, body: text ? JSON.parse(text) : null, text };
+}
+
+function assertDirectProbeResponse(probe, expectedStatus, label) {
+  assert.equal(probe.response.status, expectedStatus, label);
+  assert.equal(probe.response.headers.get("content-type"), "application/json", label);
+  assert.equal(probe.response.headers.get("location"), null, label);
+  assert.equal(probe.response.headers.get("cache-control"), "no-store", label);
+  assert.ok(probe.text.length <= 4096, `${label} response body must remain bounded`);
+}
+
 async function withEmptyObjectStore(verify) {
   const server = http.createServer((request, response) => {
     if (request.method === "HEAD") {
@@ -114,6 +133,7 @@ try {
     {
       CONTENT_STORAGE_MODE: "filesystem",
       CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+      CONTENT_RESTORE_TIMESTAMP: "2026-01-01T00:00:00Z",
     },
     async ({ origin, apiKey }) => {
       const unauthorized = await readHealth(origin);
@@ -128,6 +148,40 @@ try {
         storage: { mode: "filesystem", provider: "filesystem", ready: true },
       });
       assert.doesNotMatch(JSON.stringify(body), new RegExp(filesystemPath));
+
+      for (const method of ["GET", "HEAD"]) {
+        for (const accept of [undefined, "*/*", "application/json"]) {
+          for (const pathname of ["/livez", "/readyz"]) {
+            const label = `${method} ${pathname} accept=${accept ?? "unset"}`;
+            const probe = await readProbe(origin, pathname, { method, accept });
+            assertDirectProbeResponse(probe, 200, label);
+            if (method === "HEAD") {
+              assert.equal(probe.text, "", label);
+            }
+          }
+        }
+      }
+
+      const live = await readProbe(origin, "/livez");
+      assert.deepEqual(live.body, { status: "alive" });
+
+      const ready = await readProbe(origin, "/readyz");
+      assert.deepEqual(ready.body, {
+        status: "ready",
+        storage: {
+          mode: "filesystem",
+          provider: "filesystem",
+          catalogGeneration: null,
+          migrationState: "steady",
+          writerEpoch: "1",
+          casConflicts: 0,
+          writeFrozen: false,
+          mirrorLag: 0,
+          parityMismatch: false,
+          restoreTimestamp: "2026-01-01T00:00:00.000Z",
+          ready: true,
+        },
+      });
     }
   );
 
@@ -152,6 +206,28 @@ try {
           storage: { mode: "object", provider: "object", ready: true },
         });
         assert.doesNotMatch(JSON.stringify(body), /127\.0\.0\.1|health-/);
+
+        const ready = await readProbe(origin, "/readyz");
+        assert.equal(ready.response.status, 200);
+        assert.equal(ready.body.storage.catalogGeneration, 0);
+      }
+    );
+
+    await withServer(
+      {
+        CONTENT_STORAGE_MODE: "object",
+        CONTENT_OBJECT_ENDPOINT: endpoint,
+        CONTENT_OBJECT_BUCKET: `health-${randomUUID()}`,
+        CONTENT_OBJECT_FORCE_PATH_STYLE: "true",
+        CONTENT_OBJECT_REQUEST_TIMEOUT_MS: "1000",
+        CONTENT_OBJECT_MAX_ATTEMPTS: "1",
+        CONTENT_CATALOG_EXPECTED_GENERATION: "1",
+        AWS_SHARED_CREDENTIALS_FILE: runtimeCredentialFile,
+        AWS_PROFILE: "health",
+      },
+      async ({ origin }) => {
+        assert.equal((await readProbe(origin, "/livez")).response.status, 200);
+        assert.equal((await readProbe(origin, "/readyz")).response.status, 503);
       }
     );
   });
@@ -200,8 +276,191 @@ try {
         storage: { mode: "object", provider: "object", ready: false },
       });
       assert.doesNotMatch(JSON.stringify(body), /health-test|127\.0\.0\.1/);
+
+      const live = await readProbe(origin, "/livez");
+      assert.equal(live.response.status, 200);
+      assert.deepEqual(live.body, { status: "alive" });
+      const ready = await readProbe(origin, "/readyz", { accept: "*/*" });
+      assertDirectProbeResponse(ready, 503, "unavailable GET /readyz");
+      assert.equal(ready.response.headers.get("retry-after"), "30");
+      assert.deepEqual(ready.body, {
+        status: "unavailable",
+        storage: { ready: false },
+      });
     }
   );
+
+  for (const environment of [
+    {
+      CONTENT_STORAGE_MODE: "filesystem",
+      CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+      CONTENT_MIGRATION_STATE: "cutover",
+      CONTENT_MIGRATION_REQUIRED_STATE: "steady",
+    },
+    {
+      CONTENT_STORAGE_MODE: "filesystem",
+      CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+      CONTENT_WRITER_EPOCH: "2",
+      CONTENT_WRITER_REQUIRED_EPOCH: "1",
+    },
+    {
+      CONTENT_STORAGE_MODE: "filesystem",
+      CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+      CONTENT_WRITE_FROZEN: "true",
+    },
+  ]) {
+    await withServer(environment, async ({ origin, apiKey }) => {
+      assert.equal((await readProbe(origin, "/livez")).response.status, 200);
+      if (environment.CONTENT_WRITE_FROZEN !== "true") {
+        assert.equal((await readProbe(origin, "/readyz")).response.status, 503);
+      }
+      const mutation = await fetch(new URL("/api/posts", origin), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-api-key": apiKey,
+        },
+        body: JSON.stringify({}),
+      });
+      assert.equal(mutation.status, 503);
+    });
+  }
+
+  const oversizedDiagnostic = "x".repeat(4096);
+  for (const { environment, rejectedValue } of [
+    {
+      environment: {
+        CONTENT_MIGRATION_STATE: "token-like=value",
+        CONTENT_MIGRATION_REQUIRED_STATE: "token-like=value",
+      },
+      rejectedValue: "token-like=value",
+    },
+    {
+      environment: {
+        CONTENT_MIGRATION_STATE: "steady\nspoofed",
+        CONTENT_MIGRATION_REQUIRED_STATE: "steady\nspoofed",
+      },
+      rejectedValue: "steady\nspoofed",
+    },
+    {
+      environment: {
+        CONTENT_MIGRATION_STATE: oversizedDiagnostic,
+        CONTENT_MIGRATION_REQUIRED_STATE: oversizedDiagnostic,
+      },
+      rejectedValue: oversizedDiagnostic,
+    },
+    {
+      environment: {
+        CONTENT_WRITER_EPOCH: "epoch-token-like-value",
+        CONTENT_WRITER_REQUIRED_EPOCH: "epoch-token-like-value",
+      },
+      rejectedValue: "epoch-token-like-value",
+    },
+    {
+      environment: {
+        CONTENT_WRITER_EPOCH: oversizedDiagnostic,
+        CONTENT_WRITER_REQUIRED_EPOCH: oversizedDiagnostic,
+      },
+      rejectedValue: oversizedDiagnostic,
+    },
+  ]) {
+    await withServer(
+      {
+        CONTENT_STORAGE_MODE: "filesystem",
+        CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+        ...environment,
+      },
+      async ({ origin, apiKey }) => {
+        const ready = await readProbe(origin, "/readyz");
+        assert.equal(ready.response.status, 503);
+        assert.deepEqual(ready.body, {
+          status: "unavailable",
+          storage: { ready: false },
+        });
+        assert.doesNotMatch(JSON.stringify(ready.body), new RegExp(rejectedValue));
+
+        const mutation = await fetch(new URL("/api/posts", origin), {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            "x-api-key": apiKey,
+          },
+          body: JSON.stringify({}),
+        });
+        assert.equal(mutation.status, 503);
+      }
+    );
+  }
+
+  for (const restoreTimestamp of [
+    "credential-like=value",
+    "2026-01-01T00:00:00Z\nspoofed",
+    oversizedDiagnostic,
+  ]) {
+    await withServer(
+      {
+        CONTENT_STORAGE_MODE: "filesystem",
+        CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+        CONTENT_RESTORE_TIMESTAMP: restoreTimestamp,
+      },
+      async ({ origin }) => {
+        const ready = await readProbe(origin, "/readyz");
+        assert.equal(ready.response.status, 200);
+        assert.equal(ready.body.storage.restoreTimestamp, null);
+        assert.doesNotMatch(
+          JSON.stringify(ready.body),
+          new RegExp(restoreTimestamp)
+        );
+      }
+    );
+  }
+
+  for (const diagnosticEnvironment of [
+    {
+      CONTENT_MIRROR_LAG: "1e3",
+      CONTENT_WRITE_FROZEN: "credential-like=value",
+      CONTENT_PARITY_MISMATCH: "true\nspoofed",
+    },
+    {
+      CONTENT_MIRROR_LAG: oversizedDiagnostic,
+      CONTENT_WRITE_FROZEN: oversizedDiagnostic,
+      CONTENT_PARITY_MISMATCH: oversizedDiagnostic,
+    },
+  ]) {
+    await withServer(
+      {
+        CONTENT_STORAGE_MODE: "filesystem",
+        CONTENT_STORAGE_FILESYSTEM_PATH: filesystemPath,
+        ...diagnosticEnvironment,
+      },
+      async ({ origin, apiKey }) => {
+        const ready = await readProbe(origin, "/readyz");
+        assert.equal(ready.response.status, 200);
+        assert.equal(ready.body.storage.mirrorLag, 0);
+        assert.equal(ready.body.storage.writeFrozen, false);
+        assert.equal(ready.body.storage.parityMismatch, false);
+        for (const rawValue of Object.values(diagnosticEnvironment)) {
+          assert.doesNotMatch(JSON.stringify(ready.body), new RegExp(rawValue));
+        }
+
+        for (const method of ["POST", "PATCH", "DELETE"]) {
+          const mutation = await fetch(new URL("/api/posts", origin), {
+            method,
+            headers: {
+              "content-type": "application/json",
+              "x-api-key": apiKey,
+            },
+            body: method === "DELETE" ? undefined : JSON.stringify({}),
+          });
+          assert.equal(
+            mutation.status,
+            503,
+            `${method} must fail closed for malformed write-freeze admission`
+          );
+        }
+      }
+    );
+  }
 } finally {
   await fs.rm(filesystemPath, { recursive: true, force: true });
 }

--- a/tests/deploymentRolloutContract.test.mjs
+++ b/tests/deploymentRolloutContract.test.mjs
@@ -37,6 +37,13 @@ function renderChart(setValues = []) {
   });
 }
 
+function assertRenderFails(setValues, message) {
+  assert.throws(
+    () => renderChart(setValues),
+    error => String(error.stderr ?? error.message).includes(message)
+  );
+}
+
 function renderedDocument(renderedChart, kind) {
   return renderedChart
     .split(/^---\s*$/m)
@@ -70,6 +77,7 @@ test("pull request CI runs the repository tests before linting and building", ()
 });
 
 test("filesystem defaults render the retained PVC and mount it at the live posts path", () => {
+  assert.match(values, /contentStorage:[\s\S]*mode:\s*filesystem/);
   assert.match(values, /contentStorage:[\s\S]*filesystem:[\s\S]*pvc:[\s\S]*create:\s*true/);
   assert.match(values, /pvc:[\s\S]*mount:\s*true/);
   assert.match(values, /existingClaim:\s*bd-site-posts-pvc/);
@@ -89,17 +97,29 @@ test("filesystem defaults render the retained PVC and mount it at the live posts
   assert.doesNotMatch(deployment, /emptyDir:/);
 });
 
-test("preserved-but-unmounted mode retains the PVC without any content volume", () => {
+test("object mode retains the rollback PVC without any content volume", () => {
+  const rendered = renderChart(["contentStorage.mode=object"]);
+  const pvc = renderedDocument(rendered, "PersistentVolumeClaim");
+  const deployment = renderedDocument(rendered, "Deployment");
+
+  assert.ok(pvc, "object mode must continue rendering the rollback PVC");
+  assert.ok(deployment, "object mode must include the deployment");
+  assert.match(pvc, /name: bd-site-posts-pvc/);
+  assert.match(pvc, /helm\.sh\/resource-policy: keep/);
+  assert.doesNotMatch(deployment, /posts-content/);
+  assert.doesNotMatch(deployment, /emptyDir:/);
+});
+
+test("filesystem mount=false retains the rollback PVC without attaching content storage", () => {
   const rendered = renderChart(["contentStorage.filesystem.pvc.mount=false"]);
   const pvc = renderedDocument(rendered, "PersistentVolumeClaim");
   const deployment = renderedDocument(rendered, "Deployment");
 
-  assert.ok(pvc, "preserved mode must continue rendering the posts PVC");
-  assert.ok(deployment, "preserved mode must include the deployment");
+  assert.ok(pvc, "mount=false must continue rendering the rollback PVC");
+  assert.ok(deployment, "mount=false must include the deployment");
   assert.match(pvc, /name: bd-site-posts-pvc/);
   assert.match(pvc, /helm\.sh\/resource-policy: keep/);
   assert.doesNotMatch(deployment, /posts-content/);
-  assert.doesNotMatch(deployment, /\/app\/src\/data\/blog/);
   assert.doesNotMatch(deployment, /emptyDir:/);
 });
 
@@ -163,13 +183,78 @@ test("Helm defaults preserve local chart behavior when workflow overrides are ab
   assert.match(deploymentTemplate, /default \.Values\.image\.tag/);
 });
 
-test("single-replica ReadWriteOnce deployments replace pods without overlapping volume mounts", () => {
+test("filesystem and mirror deployments replace one pod without overlapping PVC mounts", () => {
   assert.match(values, /replicaCount:\s*1/);
   assert.match(values, /accessMode:\s*ReadWriteOnce/);
-  assert.match(deploymentTemplate, /strategy:[\s\S]*type:\s*Recreate/);
-  assert.doesNotMatch(deploymentTemplate, /type:\s*RollingUpdate/);
-  assert.doesNotMatch(deploymentTemplate, /rollingUpdate:/);
-  assert.doesNotMatch(deploymentTemplate, /podAffinity:/);
+  for (const mode of ["filesystem", "filesystem-mirror", "object-mirror"]) {
+    const deployment = renderedDocument(
+      renderChart([`contentStorage.mode=${mode}`]),
+      "Deployment"
+    );
+    assert.match(deployment, /strategy:[\s\S]*type: Recreate/);
+    assert.match(deployment, /name: posts-content/);
+    assert.doesNotMatch(deployment, /rollingUpdate:/);
+  }
+});
+
+test("object mode is stateless and uses a bounded zero-unavailable rolling update", () => {
+  const deployment = renderedDocument(
+    renderChart(["contentStorage.mode=object"]),
+    "Deployment"
+  );
+  assert.match(deployment, /type: RollingUpdate/);
+  assert.match(deployment, /maxUnavailable: 0/);
+  assert.match(deployment, /maxSurge: 1/);
+  assert.doesNotMatch(deployment, /posts-content|emptyDir:/);
+});
+
+test("Helm rejects invalid modes and unsafe replica combinations", () => {
+  assertRenderFails(
+    ["contentStorage.mode=invalid"],
+    "contentStorage.mode must be one of"
+  );
+  for (const mode of ["filesystem", "filesystem-mirror", "object-mirror"]) {
+    assertRenderFails(
+      [`contentStorage.mode=${mode}`, "replicaCount=2"],
+      "requires replicaCount=1"
+    );
+  }
+  assertRenderFails(
+    ["contentStorage.mode=object", "replicaCount=2"],
+    "multiReplicaConcurrencySafe=true"
+  );
+
+  const admitted = renderedDocument(
+    renderChart([
+      "contentStorage.mode=object",
+      "replicaCount=2",
+      "contentStorage.multiReplicaConcurrencySafe=true",
+    ]),
+    "Deployment"
+  );
+  assert.match(admitted, /replicas: 2/);
+  assert.match(admitted, /type: RollingUpdate/);
+});
+
+test("all storage modes render non-secret runtime configuration and dedicated probes", () => {
+  for (const mode of ["filesystem", "object", "filesystem-mirror", "object-mirror"]) {
+    const deployment = renderedDocument(
+      renderChart([`contentStorage.mode=${mode}`]),
+      "Deployment"
+    );
+    assert.match(
+      deployment,
+      new RegExp(`name: CONTENT_STORAGE_MODE\\s+value: "${mode}"`)
+    );
+    assert.match(deployment, /readinessProbe:[\s\S]*path: \/readyz/);
+    assert.match(deployment, /livenessProbe:[\s\S]*path: \/livez/);
+    assert.match(
+      deployment,
+      /startupProbe:[\s\S]*path: \/livez[\s\S]*failureThreshold: 24/
+    );
+    assert.match(deployment, /name: CONTENT_OBJECT_BUCKET/);
+    assert.match(deployment, /name: CONTENT_WRITER_EPOCH/);
+  }
 });
 
 test("deployment workflow fails closed on missing or mismatched image identity", () => {
@@ -194,6 +279,41 @@ test("deployment uses a dedicated service account with one durable GHCR pull sec
   assert.match(serviceAccountTemplate, /name:\s*\{\{ \.Values\.serviceAccount\.name \}\}/);
   assert.match(serviceAccountTemplate, /imagePullSecrets:[\s\S]*name:\s*\{\{ \.Values\.imagePullSecret\.name \}\}/);
   assert.match(deploymentTemplate, /serviceAccountName:\s*\{\{ \.Values\.serviceAccount\.name \}\}/);
+});
+
+test("Doppler credentials stay in a runtime Kubernetes Secret reference", () => {
+  const syntheticCredential = "synthetic-doppler-credential-marker";
+  const rendered = renderChart([`dopplerToken=${syntheticCredential}`]);
+  const deployment = renderedDocument(rendered, "Deployment");
+
+  assert.ok(deployment, "render must include the deployment");
+  assert.doesNotMatch(rendered, new RegExp(syntheticCredential));
+  assert.match(
+    deployment,
+    /name: DOPPLER_TOKEN\s+valueFrom:\s+secretKeyRef:\s+name: "?bd-site-doppler"?\s+key: "?token"?/
+  );
+  assert.match(
+    values,
+    /runtimeSecrets:[\s\S]*doppler:[\s\S]*name: bd-site-doppler[\s\S]*key: token/
+  );
+  assert.doesNotMatch(values, /^dopplerToken:/m);
+  assert.doesNotMatch(deploymentTemplate, /\.Values\.dopplerToken/);
+});
+
+test("deployment workflow reconciles the runtime Secret without exposing it to Helm or diagnostics", () => {
+  assert.match(workflow, /name: Reconcile Doppler runtime secret/);
+  assert.match(workflow, /DOPPLER_TOKEN_PATH:\s*\$\{\{ runner\.temp \}\}\/doppler-token/);
+  assert.match(workflow, /umask 077/);
+  assert.match(workflow, /chmod 600 "\$\{DOPPLER_TOKEN_PATH\}"/);
+  assert.match(
+    workflow,
+    /secret generic "\$\{DOPPLER_RUNTIME_SECRET\}"[\s\S]*--from-file="\$\{DOPPLER_RUNTIME_SECRET_KEY\}=\$\{DOPPLER_TOKEN_PATH\}"[\s\S]*--dry-run=client -o yaml \| kubectl apply/
+  );
+  assert.doesNotMatch(workflow, /--set(?:-string)?\s+dopplerToken/);
+  assert.doesNotMatch(workflow, /helm[^\n]*DOPPLER_TOKEN/);
+  assert.doesNotMatch(workflow, /kubectl (?:get|describe) secret/);
+  assert.match(workflow, /name: Cleanup temporary credential files[\s\S]*if:\s*always\(\)/);
+  assert.match(workflow, /rm -f "\$\{DOPPLER_TOKEN_PATH\}"/);
 });
 
 test("temporary pull credentials are env-bound, file-backed, promoted only after preflight", () => {
@@ -235,6 +355,14 @@ test("post-rollout public checks are bounded and roll back to the verified previ
   assert.match(workflow, /PREVIOUS_REVISION=.*helm history bd-site -n "\$\{KUBE_NAMESPACE\}"/);
   assert.match(workflow, /for path in "\/" "\/posts\/" "\/rss\.xml" "\/sitemap\.xml" "\/sitemap-posts\.xml"/);
   assert.match(workflow, /curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30/);
+  assert.match(
+    workflow,
+    /curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "https:\/\/berryhill\.dev\/livez"[\s\S]*grep -Fq '\"status\":\"alive\"'/
+  );
+  assert.match(
+    workflow,
+    /curl -fsS --retry 3 --retry-delay 2 --connect-timeout 10 --max-time 30 "https:\/\/berryhill\.dev\/readyz"[\s\S]*grep -Fq '\"status\":\"ready\"'/
+  );
   assert.match(workflow, /helm rollback bd-site "\$\{PREVIOUS_REVISION\}" -n "\$\{KUBE_NAMESPACE\}" --wait --timeout 3m/);
   assert.match(workflow, /kubectl rollout status deployment\/bd-site -n "\$\{KUBE_NAMESPACE\}" --timeout=180s/);
   assert.doesNotMatch(workflow, /curl -fsS https:\/\/berryhill\.dev\/posts\/ >\/dev\/null \|\| true/);

--- a/tests/url.test.mjs
+++ b/tests/url.test.mjs
@@ -92,8 +92,10 @@ test("canonical HTML URLs enforce trailing slashes for route-like paths", () => 
   );
 });
 
-test("trailing slash enforcement excludes APIs, XML feeds, assets, and generated images", () => {
+test("trailing slash enforcement excludes APIs, probes, XML feeds, assets, and generated images", () => {
   assert.equal(shouldEnforceTrailingSlash("/api/posts"), false);
+  assert.equal(shouldEnforceTrailingSlash("/livez"), false);
+  assert.equal(shouldEnforceTrailingSlash("/readyz"), false);
   assert.equal(shouldEnforceTrailingSlash("/robots.txt"), false);
   assert.equal(shouldEnforceTrailingSlash("/sitemap.xml"), false);
   assert.equal(shouldEnforceTrailingSlash("/rss.xml"), false);
@@ -107,6 +109,8 @@ test("HTML alternate path detection ignores non-HTML crawl surfaces", () => {
   assert.equal(getAlternateHtmlPathname("/about"), "/about/");
   assert.equal(getAlternateHtmlPathname("/"), null);
   assert.equal(getAlternateHtmlPathname("/api/posts"), null);
+  assert.equal(getAlternateHtmlPathname("/livez"), null);
+  assert.equal(getAlternateHtmlPathname("/readyz"), null);
   assert.equal(getAlternateHtmlPathname("/rss.xml"), null);
   assert.equal(getAlternateHtmlPathname("/posts/example/index.png"), null);
 });
@@ -158,6 +162,21 @@ test("canonical HTML redirect helper excludes canonical, API, and file-like path
     getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/api/posts", "text/html"),
     null
   );
+  for (const method of ["GET", "HEAD"]) {
+    for (const pathname of ["/livez", "/readyz"]) {
+      for (const accept of [undefined, "*/*", "application/json"]) {
+        assert.equal(
+          getCanonicalHtmlRedirectLocation(
+            method,
+            `https://berryhill.dev${pathname}`,
+            accept
+          ),
+          null,
+          `${method} ${pathname} accept=${accept ?? "unset"}`
+        );
+      }
+    }
+  }
   assert.equal(
     getCanonicalHtmlRedirectLocation("GET", "https://berryhill.dev/rss.xml", "text/html"),
     null


### PR DESCRIPTION
## Summary

Implements the deployable stateless/runtime-operation slice for #160 without performing the production content cutover.

- adds storage-mode-aware Helm mounts, strategies, probes, and replica admission
- adds process-only `/livez` and storage-aware `/readyz`
- adds runtime readiness evidence for primary store, catalog, migration phase, and writer epoch
- preserves the rollback PVC while object mode renders no content mount or `emptyDir`
- keeps production default on filesystem mode
- wires `DOPPLER_TOKEN` only through a Kubernetes `secretKeyRef`

Closes #160

## Acceptance covered

- Filesystem and mirror modes mount the retained PVC, enforce one replica, and use `Recreate`.
- Object mode omits the content volume and volume mount, preserves the rollback PVC, and uses `RollingUpdate` with `maxUnavailable: 0` and bounded surge.
- Unsafe storage-mode/replica combinations fail rendering unless the explicit concurrency-safety gate is enabled.
- `/livez` remains process-only; `/readyz` fails closed on selected-primary-store, catalog, migration-state, or writer-epoch mismatch without selecting a secondary backend.
- Deployment diagnostics remain bounded and credential-free.

## Prior rejected attempt resolved

An earlier local review rejected the implementation because the chart rendered `DOPPLER_TOKEN` as a literal Helm value and the workflow passed it via `--set dopplerToken`. This head replaces that path with non-secret Secret name/key selectors, reconciles the runtime Secret through a permission-restricted temporary input, removes the credential-bearing Helm argument, and always cleans the temporary file. No earlier PR was opened and no contaminated remote branch existed.

## Changed surfaces

Path boundary: deployment-touching and app/source-code-touching.

- Helm Deployment/values/example and chart operations documentation
- GitHub deployment workflow
- Astro liveness/readiness routes and runtime readiness helper
- post API readiness diagnostics
- URL route classification
- deterministic runtime, URL, Helm-render, rollout, and secret-containment tests
- API operations documentation

## Validation

- `pnpm exec tsx tests/deploymentRolloutContract.test.mjs` — PASS (24/24)
- `pnpm exec tsx tests/blogHealthApiRoute.test.mjs` — PASS (5/5)
- `pnpm exec tsx tests/url.test.mjs` — PASS (16/16)
- independent synthetic Helm credential-containment render — PASS; marker absent, `DOPPLER_TOKEN` references the configured Secret/key
- all storage-mode and mount render matrices — PASS
- `helm lint ./helm` — PASS
- `pnpm test` — PASS
- `pnpm run lint` — PASS
- `pnpm run format:check` — PASS
- `pnpm run build` — PASS
- `git diff --check` — PASS

## Visual and crawl evidence

No visual surface changes are in scope. The production Astro build passed, route tests prove `/livez` and `/readyz` are not canonical-HTML redirect targets, and crawl/social-preview behavior remains unchanged.

## Residual risks / boundaries

- This PR does not provision production object storage, credentials, buckets, or perform backfill/cutover.
- Production remains in filesystem mode until the separately gated migration issue.
- Live rollout and endpoint verification remain post-merge deployment evidence, distinct from repository and rendered-chart verification.
